### PR TITLE
Review broker and schema registry URLs

### DIFF
--- a/docs/environments.rst
+++ b/docs/environments.rst
@@ -43,13 +43,8 @@ Intended audience: Observers and Commissioning team.
 - Chronograf: ``https://summit-lsp.lsst.codes/chronograf``
 - InfluxDB HTTP API: ``https://summit-lsp.lsst.codes/influxdb``
 - Kafdrop UI: ``https://summit-lsp.lsst.codes/kafdrop``
-- Kafka brokers:
-
-  - ``sasquatch-summit-kafka-0.lsst.codes``
-  - ``sasquatch-summit-kafka-1.lsst.codes``
-  - ``sasquatch-summit-kafka-2.lsst.codes``
-
-- Kafka bootstrap server: ``sasquatch-summit-kafka-bootstrap.lsst.codes``
+- Kafka bootstrap server: ``sasquatch-summit-kafka-bootstrap.lsst.codes:9094``
+- Schema Registry: ``http://sasquatch-schema-registry.sasquatch:8081`` (cluster internal only)
 - Kafka REST proxy API: ``https://summit-lsp.lsst.codes/sasquatch-rest-proxy``
 
 .. _usdf:
@@ -64,10 +59,9 @@ Intended audience: Project staff.
 - Chronograf: ``https://usdf-rsp.slac.stanford.edu/chronograf``
 - InfluxDB HTTP API: ``https://usdf-rsp.slac.stanford.edu/influxdb``
 - Kafdrop UI: ``https://usdf-rsp.slac.stanford.edu/kafdrop``
-- Kafka brokers:
-  (not yet available)
 - Kafka boostrap server:
   (not yet available)
+- Schema Registry: ``http://sasquatch-schema-registry.sasquatch:8081`` (cluster internal only)
 - Kafka REST proxy API: ``https://usdf-rsp.slac.stanford.edu/sasquatch-rest-proxy``
 
 .. _usdfdev:
@@ -82,10 +76,9 @@ Intended audience: Project staff.
 - Chronograf: ``https://usdf-rsp-dev.slac.stanford.edu/chronograf``
 - InfluxDB HTTP API: ``https://usdf-rsp-dev.slac.stanford.edu/influxdb``
 - Kafdrop UI: ``https://usdf-rsp-dev.slac.stanford.edu/kafdrop``
-- Kafka brokers:
-  (not yet available)
 - Kafka boostrap server:
   (not yet available)
+- Schema Registry: ``http://sasquatch-schema-registry.sasquatch:8081`` (cluster internal only)
 - Kafka REST proxy API: ``https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy``
 
 .. _tts:
@@ -100,15 +93,9 @@ Intended audience: Telescope & Site team.
 - Chronograf: ``https://tucson-teststand.lsst.codes/chronograf``
 - InfluxDB HTTP API: ``https://tucson-teststand.lsst.codes/influxdb``
 - Kafdrop UI: ``https://tucson-teststand.lsst.codes/kafdrop``
-- Kafka brokers:
-
-  - ``sasquatch-tts-kafka-0.lsst.codes``
-  - ``sasquatch-tts-kafka-1.lsst.codes``
-  - ``sasquatch-tts-kafka-2.lsst.codes``
-
-- Kafka bootstrap server: ``sasquatch-tts-kafka-bootstrap.lsst.codes``
+- Kafka bootstrap server: ``sasquatch-tts-kafka-bootstrap.lsst.codes:9094``
+- Schema Registry: ``http://sasquatch-schema-registry.sasquatch:8081`` (cluster internal only)
 - Kafka REST proxy API: ``https://tucson-teststand.lsst.codes/sasquatch-rest-proxy``
-
 
 .. _bts:
 
@@ -122,11 +109,6 @@ Intended audience: Telescope & Site team.
 - Chronograf: ``https://base-lsp.lsst.codes/chronograf``
 - InfluxDB HTTP API: ``https://base-lsp.lsst.codes/influxdb``
 - Kafdrop UI: ``https://base-lsp.lsst.codes/kafdrop``
-- Kafka brokers:
-
-  - ``sasquatch-base-kafka-0.lsst.codes``
-  - ``sasquatch-base-kafka-1.lsst.codes``
-  - ``sasquatch-base-kafka-2.lsst.codes``
-
-- Kafka bootstrap server: ``sasquatch-base-kafka-bootstrap.lsst.codes``
+- Kafka bootstrap server: ``sasquatch-base-kafka-bootstrap.lsst.codes:9094``
+- Schema Registry: ``http://sasquatch-schema-registry.sasquatch:8081`` (cluster internal only)
 - Kafka REST proxy API: ``https://base-lsp.lsst.codes/sasquatch-rest-proxy``


### PR DESCRIPTION
- Note that the schema registry URL is cluster internal only (for the moment).