### PR TITLE
Add cluster external Schema Registry API URL for TTS

### DIFF
--- a/docs/environments.rst
+++ b/docs/environments.rst
@@ -95,8 +95,10 @@ Intended audience: Telescope & Site team.
 - Kafdrop UI: ``https://tucson-teststand.lsst.codes/kafdrop``
 - Kafka bootstrap server: ``sasquatch-tts-kafka-bootstrap.lsst.codes:9094``
 - Schema Registry:
+
   - ``http://sasquatch-schema-registry.sasquatch:8081`` (cluster internal)
   - ``https://tucson-teststand.lsst.codes/schema-registry`` (cluster external)
+
 - Kafka REST proxy API: ``https://tucson-teststand.lsst.codes/sasquatch-rest-proxy``
 
 .. _bts:


### PR DESCRIPTION
- This is required for the kafka-based salobj, specially for CSCs that run external to the cluster. Note that there's no authentication for the SR API yet.