### PR TITLE
Improve labels to select connectors

### DIFF
--- a/docs/developer-guide/connectors.rst
+++ b/docs/developer-guide/connectors.rst
@@ -106,14 +106,13 @@ To list the connectors deployed in a Sasquatch environment, run:
 
 .. code:: bash
 
-  kubectl get deploy -l app=sasquatch-telegraf-kafka-consumer -n sasquatch
+  kubectl get deploy -l app.kubernetes.io/name=sasquatch-telegraf -n sasquatch
 
-To view the logs of a connector or multiple connectors run:
+To view the logs of a connector or multiple connector instances run:
 
 .. code:: bash
 
-  kubectl logs sasquatch-telegraf-<connector-name> -n sasquatch
-  kubectl logs -l app=sasquatch-telegraf-kafka-consumer --tail=5  -n sasquatch
+  kubectl logs -l app.kubernetes.io/instance=sasquatch-telegraf-<connector-name> --tail=5  -n sasquatch
 
 To stop a connector, run:
 

--- a/docs/developer-guide/strimzi-updates.rst
+++ b/docs/developer-guide/strimzi-updates.rst
@@ -38,7 +38,7 @@ Note that you do not explicitly set the Kafka ``metadataVersion`` in Sasquatch; 
     This happens because, while the first broker will be running the new version supported by the operator, the third broker will still be on an unsupported version.
     Since Sasquatch requires a minimum of two in-sync replicas for each Kafka topic, this mismatch would cause an outage.
 
-    If your current version of Kafka is not supported by the new version of the operator, to avoid an outage during the upgrades, first update Kafka to a supported version and then update the operator. 
+    If your current version of Kafka is not supported by the new version of the operator, to avoid an outage during the upgrades, first update Kafka to a supported version and then update the operator.
 
 Refer to the `Strimzi documentation`_ for more details.
 


### PR DESCRIPTION
- Use k8s recommended labels, allow to select connector pods using app.kubernetes.io/instance label