### PR TITLE
Fix typo in security protocol docs

### DIFF
--- a/docs/user-guide/directconnection.rst
+++ b/docs/user-guide/directconnection.rst
@@ -135,6 +135,7 @@ If your app is a `Safir`_ app, you can use the `Safir Kafka helpers <https://saf
          containers:
          - env:
            - name: KAFKA_SECURITY_PROTOCOL
+             valueFrom:
                secretKeyRef:
                  key: securityProtocol
                  name: myapp-kafka


### PR DESCRIPTION
The security protocol in the docs was missing `valuefrom` and wasn't mirroring correctly to the deployed image