### PR TITLE
Use Repertoire API for authentication

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -3,7 +3,10 @@
 .. _SAL interfaces: https://ts-xml.lsst.io/sal_interfaces/index.html
 
 .. _InfluxDB: https://docs.influxdata.com/enterprise_influxdb/v1/
+.. _InfluxQL queries: https://docs.influxdata.com/influxdb/v1/query_language/spec/
+.. _EXPLAIN ANALYZE: https://docs.influxdata.com/influxdb/v1/query_language/spec/#explain-analyze
 .. _InfluxQL documentation: https://docs.influxdata.com/influxdb/v1/query_language/
+.. _Use comments with InfluxQL statements: https://docs.influxdata.com/influxdb/v1/query_language/spec/#comments
 .. _tags versus fields: https://docs.influxdata.com/influxdb3/cloud-serverless/write-data/best-practices/schema-design/#tags-versus-fields
 .. _Flux documentation: https://docs.influxdata.com/influxdb/v1/flux/
 .. _Chronograf documentation: https://docs.influxdata.com/chronograf/v1

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -19,6 +19,7 @@
 .. _Repertoire: https://repertoire.lsst.io
 .. _Repertoire client: https://repertoire.lsst.io/user-guide/influxdb.html
 .. _Repertoire API documentation: https://usdf-rsp.slac.stanford.edu/repertoire/redoc#operation/get_influxdb_repertoire_discovery_influxdb__database__get
+.. _Getting InfluxDB connection information: https://repertoire.lsst.io/user-guide/influxdb.html
 
 .. _Kapacitor documentation: https://docs.influxdata.com/kapacitor/v1
 

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -17,6 +17,8 @@
 .. _LSST Science Pipelines: https://pipelines.lsst.io
 .. _EFD client: https://efd-client.lsst.io
 .. _Repertoire: https://repertoire.lsst.io
+.. _Repertoire client: https://repertoire.lsst.io/user-guide/influxdb.html
+.. _Repertoire API documentation: https://usdf-rsp.slac.stanford.edu/repertoire/redoc#operation/get_influxdb_repertoire_discovery_influxdb__database__get
 
 .. _Kapacitor documentation: https://docs.influxdata.com/kapacitor/v1
 

--- a/docs/user-guide/influxdb-api.rst
+++ b/docs/user-guide/influxdb-api.rst
@@ -4,7 +4,11 @@
 InfluxDB API
 ############
 
-This guide describes how to access the InfluxDB API, which can be useful for services or applications that need to query InfluxDB directly without using the `EFD client`_.
+This guide explains how to query InfluxDB databases directly using the InfluxDB API.
+
+In most cases, the `EFD client`_ is the easiest and recommended way to query data from the EFD and other databases.
+
+If the client isn't available in your environment, or if you prefer a more lightweight method, you can use the InfluxDB API as an alternative.
 
 InfluxDB connection information
 -------------------------------

--- a/docs/user-guide/influxdb-api.rst
+++ b/docs/user-guide/influxdb-api.rst
@@ -9,15 +9,29 @@ This guide describes how to access the InfluxDB API, which can be useful for ser
 InfluxDB connection information
 -------------------------------
 
-The InfluxDB API uses simple authentication based on username and password credentials, currently there is no support for token-based authentication.
+The InfluxDB API uses simple authentication based on username and password credentials.
+Currently, there is no support for token-based authentication.
 
 To query the InfluxDB API, you need the InfluxDB API URL, the database name, and the username and password credentials.
-The recommended way to retrieve this information from the RSP is using the `Repertoire client`_.
 
-Alternatively, you can retrieve the InfluxDB connection information directly from the Repertoire API endpoint  ``/repertoire/discovery/influxdb``.
-For example, to retrieve InfluxDB connection information for the ``usdf_efd`` database at USDF you can send a GET request to the following URL:
+If you are inside the RSP notebook aspect, you can find this information using the ``lsst.rsp`` package.
+For example, to retrieve InfluxDB connection information for the ``usdf_efd`` database:
 
-``https://usdf-rsp.slac.stanford.edu/repertoire/discovery/influxdb/usdf_efd``
+.. code:: python
+
+  from lsst.rsp import get_influxdb_credentials
+
+  info = get_influxdb_credentials("usdf_efd")
+
+If you are outside the RSP, the recommended way to retrieve this information is using the Repertoire client, see `Getting InfluxDB connection information`_ guide.
+
+Alternatively, you can also retrieve the InfluxDB connection information directly from the Repertoire API.
+For example, to retrieve InfluxDB connection information for the ``usdf_efd`` database, you can send a GET request to the following URL:
+
+``https://<repertoire-url>/discovery/influxdb/usdf_efd``
+
+where ``<repertoire-url>`` is the base URL for Repertoire.
+For Phalanx applications, the base URL for Repertoire can be obtained from ``global.repertoireUrl``.
 
 Since the returned information includes username and password credentials, this endpoint is protected and requires authentication using an access token.
 This may be a user token created through the token UI with ``"read:sasquatch"`` scope.
@@ -27,14 +41,13 @@ See the `RSP documentation`_ for more information.
 
   import requests
 
-  repertoire_url = (
-      "https://usdf-rsp.slac.stanford.edu/repertoire/discovery/influxdb/usdf_efd"
-  )
-  token = "..."  # obtained from somewhere else
+  database = "usdf_efd"  # the InfluxDB database to retrieve information for
+  repertoire_url = "..."  # the base URL for Repertoire, e.g. obtained from global.repertoireUrl in Phalanx
 
+  token = "..."  # obtained from somewhere else
   headers = {"content-type": "application/json", "Authorization": f"Bearer {token}"}
 
-  info = requests.get(f"{repertoire_url}", headers=headers)
+  info = requests.get(f"{repertoire_url}/discovery/influxdb/{database}", headers=headers)
 
 See `Repertoire API documentation`_ for more information about the returned information.
 

--- a/docs/user-guide/influxdb-api.rst
+++ b/docs/user-guide/influxdb-api.rst
@@ -4,29 +4,39 @@
 InfluxDB API
 ############
 
-This guide describes how to access the InfluxDB API, which can be useful for services or applications that need to query data stored in Sasquatch.
+This guide describes how to access the InfluxDB API, which can be useful for services or applications that need to query InfluxDB directly without using the `EFD client`_.
 
 InfluxDB connection information
 -------------------------------
 
-From the Rubin Science Platform, list the InfluxDB databases available in your environment with:
+The InfluxDB API uses simple authentication based on username and password credentials, currently there is no support for token-based authentication.
 
-.. code::
+To query the InfluxDB API, you need the InfluxDB API URL, the database name, and the username and password credentials.
+The recommended way to retrieve this information from the RSP is using the `Repertoire client`_.
 
-    from lsst.rsp list_influxdb_labels
+Alternatively, you can retrieve the InfluxDB connection information directly from the Repertoire API endpoint  ``/repertoire/discovery/influxdb``.
+For example, to retrieve InfluxDB connection information for the ``usdf_efd`` database at USDF you can send a GET request to the following URL:
 
-    list_influxdb_labels()
+``https://usdf-rsp.slac.stanford.edu/repertoire/discovery/influxdb/usdf_efd``
 
-This returns a list of database labels that you can use to retrieve connection information using the `Repertoire`_ service discovery.
-You can retrieve the connection information with:
+Since the returned information includes username and password credentials, this endpoint is protected and requires authentication using an access token.
+This may be a user token created through the token UI with ``"read:sasquatch"`` scope.
+See the `RSP documentation`_ for more information.
 
-.. code:: Python
+.. code:: python
 
-    from lsst.rsp import get_influxdb_credentials
+  import requests
 
-    get_influxdb_credentials("<database_label>")
+  repertoire_url = (
+      "https://usdf-rsp.slac.stanford.edu/repertoire/discovery/influxdb/usdf_efd"
+  )
+  token = "..."  # obtained from somewhere else
 
-To query the InfluxDB v1 API, you need the InfluxDB API URL, the database name, and the username and password credentials to connect to the database.
+  headers = {"content-type": "application/json", "Authorization": f"Bearer {token}"}
+
+  info = requests.get(f"{repertoire_url}", headers=headers)
+
+See `Repertoire API documentation`_ for more information about the returned information.
 
 
 The InfluxDB API query endpoint

--- a/docs/user-guide/influxdb-api.rst
+++ b/docs/user-guide/influxdb-api.rst
@@ -45,67 +45,30 @@ The InfluxDB API query endpoint
 Use the InfluxDB API ``/query`` endpoint to query data using the InfluxQL query language.
 See the `InfluxQL documentation`_ for more information on the supported query syntax and capabilities.
 
-Here is an example on how to query the InfluxDB v1 API using the Python requests module.
+The following example shows how to query the InfluxDB API:
 
 .. code:: python
 
-  import os
   import requests
 
+  influxdb_url = "https://usdf-rsp.slac.stanford.edu/influxdb-enterprise-data/"  # the URL of the InfluxDB API
+  database_name = "efd"  # the name of the database to query
+  auth = (
+      "username",
+      "password",
+  )  # the username and password credentials for authentication
 
-  class InfluxDBClient:
-      """A simple InfluxDB client.
+  query = """SELECT vacuum FROM "lsst.sal.ATCamera.vacuum" WHERE time > now() - 1h"""  # the InfluxQL query to send to the InfluxDB API
 
-      Parameters
-      ----------
-      url : str
-          The InfluxDB API URL
-      database_name : str
-          The name of the database to query.
-      username : str, optional
-          The username to connect to the database.
-      password : str, optional
-          The password to connect to the database.
-      """
-
-      def __init__(
-          self,
-          url: str,
-          database_name: str,
-          username: str | None = None,
-          password: str | None = None,
-      ) -> None:
-          self.url = url
-          self.database_name = database_name
-          self.auth = (username, password) if username and password else None
-
-      def query(self, query: str) -> dict:
-          """Send a query to the InfluxDB API."""
-          params = {"db": self.database_name, "q": query}
-          try:
-              response = requests.get(f"{self.url}/query", params=params, auth=self.auth)
-              response.raise_for_status()
-              return response.json()
-          except requests.exceptions.RequestException as exc:
-              raise InfluxDBError(f"An error occurred: {exc}") from exc
+  response = requests.get(
+      f"{influxdb_url}/query", params={"db": database_name, "q": query}, auth=auth
+  )
 
 
 The InfluxDB API response format
 --------------------------------
 
-The following example illustrates how to use the InfluxDB client to send a query to the InfluxDB API and the expected response format.
-
-.. code:: python
-
-  # Instantiate the InfluxDB client with the appropriate connection information
-  client = InfluxDBClient()
-
-  # Example query to the InfluxDB API
-  response = client.query(
-      """SELECT vacuum FROM "lsst.sal.ATCamera.vacuum" WHERE time > now() - 1h"""
-  )
-
-The above query retrieves the ``vacuum`` measurements for the ``ATCamera`` in the last hour, using the InfluxQL ``now()`` function to specify a time range relative to the server's current time.
+The above query retrieves the ``vacuum`` measurements for the ``ATCamera`` in the last hour.
 The InfluxDB API response is a JSON object with the following structure:
 
 .. code:: json
@@ -138,17 +101,17 @@ If you query a single topic like above the result will have a single ``series``.
 Converting the InfluxDB API response to a Pandas DataFrame
 ----------------------------------------------------------
 
-To convert the InfluxDB v1 API response to a Pandas DataFrame, you can use the following code, assuming you are sending a single query
+To convert the InfluxDB API response to a Pandas DataFrame, you can use the following code, assuming you are sending a single query
 and querying a single topic at a time like in the example above.
 
-The result is equivalent to the Pandas DataFrame you would get when using the EFD client.
+The result is equivalent to the Pandas DataFrame you would get when using the `EFD client`_.
 
 .. code:: python
 
   import pandas as pd
 
 
-  def _to_dataframe(self, response: dict) -> pd.DataFrame:
+  def to_dataframe(response: dict) -> pd.DataFrame:
       """Convert an InfluxDB response to a Pandas dataframe.
 
       Parameters
@@ -172,3 +135,6 @@ The result is equivalent to the Pandas DataFrame you would get when using the EF
       if "name" in series:
           result.name = series["name"]
       return result
+
+
+  to_dataframe(response.json())

--- a/docs/user-guide/influxdb-api.rst
+++ b/docs/user-guide/influxdb-api.rst
@@ -13,10 +13,14 @@ If the client isn't available in your environment, or if you prefer a more light
 InfluxDB connection information
 -------------------------------
 
-The InfluxDB API uses simple authentication based on username and password credentials.
-Currently, there is no support for token-based authentication.
+The InfluxDB API uses simple authentication with a username and password.
+Token-based authentication is not currently supported.
 
-To query the InfluxDB API, you need the InfluxDB API URL, the database name, and the username and password credentials.
+To query an InfluxDB database using the API, you will need the following connection details:
+
+- InfluxDB API URL
+- Database name
+- Username and password
 
 If you are inside the RSP notebook aspect, you can find this information using the ``lsst.rsp`` package.
 For example, to retrieve InfluxDB connection information for the ``usdf_efd`` database:
@@ -25,16 +29,17 @@ For example, to retrieve InfluxDB connection information for the ``usdf_efd`` da
 
   from lsst.rsp import get_influxdb_credentials
 
-  info = get_influxdb_credentials("usdf_efd")
+  get_influxdb_credentials("usdf_efd")
 
-If you are outside the RSP, the recommended way to retrieve this information is using the Repertoire client, see `Getting InfluxDB connection information`_ guide.
+If you are outside the RSP, the recommended way to retrieve this information is using the Repertoire client.
+See the `Getting InfluxDB connection information`_ guide.
 
 Alternatively, you can also retrieve the InfluxDB connection information directly from the Repertoire API.
 For example, to retrieve InfluxDB connection information for the ``usdf_efd`` database, you can send a GET request to the following URL:
 
 ``https://<repertoire-url>/discovery/influxdb/usdf_efd``
 
-where ``<repertoire-url>`` is the base URL for Repertoire.
+where ``<repertoire-url>`` is the base URL for Repertoire for your local environment.
 For Phalanx applications, the base URL for Repertoire can be obtained from ``global.repertoireUrl``.
 
 Since the returned information includes username and password credentials, this endpoint is protected and requires authentication using an access token.
@@ -45,13 +50,19 @@ See the `RSP documentation`_ for more information.
 
   import requests
 
-  database = "usdf_efd"  # the InfluxDB database to retrieve information for
   repertoire_url = "..."  # the base URL for Repertoire, e.g. obtained from global.repertoireUrl in Phalanx
 
   token = "..."  # obtained from somewhere else
   headers = {"content-type": "application/json", "Authorization": f"Bearer {token}"}
 
-  info = requests.get(f"{repertoire_url}/discovery/influxdb/{database}", headers=headers)
+  response = requests.get(
+      f"{repertoire_url}/discovery/influxdb/usdf_efd", headers=headers
+  )
+
+  response.raise_for_status()  # check for HTTP errors
+
+  info = response.json()  # Parse the JSON response into a Python dictionary
+
 
 See `Repertoire API documentation`_ for more information about the returned information.
 
@@ -68,17 +79,22 @@ The following example shows how to query the InfluxDB API:
 
   import requests
 
-  influxdb_url = "https://usdf-rsp.slac.stanford.edu/influxdb-enterprise-data/"  # the URL of the InfluxDB API
-  database_name = "efd"  # the name of the database to query
+  influxdb_url = info.get("url")  # the URL of the InfluxDB API
+  database = info.get("database")  # the name of the InfluxDB database to query
   auth = (
-      "username",
-      "password",
+      info.get("username"),
+      info.get("password"),
   )  # the username and password credentials for authentication
 
-  query = """SELECT vacuum FROM "lsst.sal.ATCamera.vacuum" WHERE time > now() - 1h"""  # the InfluxQL query to send to the InfluxDB API
+  query = """
+    SELECT vacuum
+    FROM "lsst.sal.ATCamera.vacuum"
+    WHERE time > now() - 1h
+    /* source: my-application-name */
+  """  # the InfluxQL query to send to the InfluxDB API
 
   response = requests.get(
-      f"{influxdb_url}/query", params={"db": database_name, "q": query}, auth=auth
+      f"{influxdb_url}/query", params={"db": database, "q": query}, auth=auth
   )
 
 
@@ -116,7 +132,7 @@ If you query a single topic like above the result will have a single ``series``.
 
 
 Converting the InfluxDB API response to a Pandas DataFrame
-----------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To convert the InfluxDB API response to a Pandas DataFrame, you can use the following code, assuming you are sending a single query
 and querying a single topic at a time like in the example above.

--- a/docs/user-guide/influxdb-api.rst
+++ b/docs/user-guide/influxdb-api.rst
@@ -155,3 +155,30 @@ The result is equivalent to the Pandas DataFrame you would get when using the `E
 
 
   to_dataframe(response.json())
+
+
+Best practices for querying InfluxDB databases
+----------------------------------------------
+
+When querying InfluxDB databases, keep the following best practices in mind:
+
+1. Use the Repertoire client or API to retrieve InfluxDB connection information. This ensures your application can adapt to changes in the environment.
+
+2. Whenever possible, use the InfluxDB databases at USDF even if your application is running at the Summit (for example, ``usdf_efd`` instead of ``summit_efd``). These databases are intended for user queries and help reduce the impact on Summit operations.
+
+3. Avoid querying production InfluxDB databases during development. From a development environment (such as ``usdf-rsp-dev``), use Repertoire to discover connection details for a development database (for example, ``usdfdev_efd``).
+
+4. Write efficient InfluxQL queries. Use appropriate time ranges, filters, and functions to limit the amount of data returned and reduce load on the database. You can use the ``EXPLAIN ANALYZE`` command in InfluxQL to help diagnose query performance.
+
+5. Add comments to your InfluxQL statements to help identify the origin of queries in InfluxDB logs. For example:
+
+.. code:: sql
+
+  SELECT vacuum
+  FROM "lsst.sal.ATCamera.vacuum"
+  WHERE time > now() - 1h
+  /* source: my-application-name */
+
+
+
+


### PR DESCRIPTION
- Describe how to use the Repertoire API for retrieving InfluxDB connection information and credentials.
- Improve description on how to query the InfluxDB API, the response format and example code to convert the response to a Pandas dataframe.