### PR TITLE
[DM-54806] Implement database migration in Sasquatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ env:
   # Current supported uv version. The uv documentation recommends pinning
   # this. The version should match the version used in .pre-commit-config.yaml
   # and frozen in uv.lock. It is updated by make update-deps.
-  UV_VERSION: "0.11.7"
+  UV_VERSION: "0.11.14"
 
 "on":
   merge_group: {}

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -8,7 +8,7 @@ env:
   # Current supported uv version. The uv documentation recommends pinning
   # this. The version should match the version used in .pre-commit-config.yaml
   # and frozen in uv.lock. It is updated by make update-deps.
-  UV_VERSION: "0.11.7"
+  UV_VERSION: "0.11.14"
 
 "on":
   schedule:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.11
+    rev: v0.15.13
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
@@ -15,6 +15,6 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.7
+    rev: 0.11.14
     hooks:
       - id: uv-lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,19 @@ ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-default-groups --compile-bytecode --no-editable
 
+FROM base-image AS influx-tools-image
+
+# Download the InfluxDB OSS tooling needed by migration commands.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get -y install --no-install-recommends curl ca-certificates && \
+    mkdir influxdb-1.12.3 && \
+    curl -LO "https://dl.influxdata.com/influxdb/releases/v1.12.3/influxdb-1.12.3_linux_amd64.tar.gz" && \
+    tar xf influxdb-1.12.3_linux_amd64.tar.gz -C influxdb-1.12.3 && \
+    mv "$(find influxdb-1.12.3 -type f -name influx_inspect | head -n 1)" /usr/local/bin/ && \
+    rm -rf influxdb-1.12.3 influxdb-1.12.3_linux_amd64.tar.gz /var/lib/apt/lists/*
+
 FROM base-image AS runtime-image
 
 # Create a non-root user.
@@ -63,6 +76,9 @@ RUN useradd --create-home appuser
 
 # Copy the virtualenv.
 COPY --from=install-image /app/.venv /app/.venv
+
+# Copy the InfluxDB inspection tool used by migration commands.
+COPY --from=influx-tools-image /usr/local/bin/influx_inspect /usr/local/bin/influx_inspect
 
 # Switch to the non-root user.
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     mkdir influxdb-1.12.3 && \
     curl -LO "https://dl.influxdata.com/influxdb/releases/v1.12.3/influxdb-1.12.3_linux_amd64.tar.gz" && \
     tar xf influxdb-1.12.3_linux_amd64.tar.gz -C influxdb-1.12.3 && \
+    mv "$(find influxdb-1.12.3 -type f -name influx | head -n 1)" /usr/local/bin/ && \
     mv "$(find influxdb-1.12.3 -type f -name influx_inspect | head -n 1)" /usr/local/bin/ && \
     rm -rf influxdb-1.12.3 influxdb-1.12.3_linux_amd64.tar.gz /var/lib/apt/lists/*
 
@@ -78,6 +79,7 @@ RUN useradd --create-home appuser
 COPY --from=install-image /app/.venv /app/.venv
 
 # Copy the InfluxDB inspection tool used by migration commands.
+COPY --from=influx-tools-image /usr/local/bin/influx /usr/local/bin/influx
 COPY --from=influx-tools-image /usr/local/bin/influx_inspect /usr/local/bin/influx_inspect
 
 # Switch to the non-root user.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 FROM base-image AS install-image
 
 # Install uv.
-COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /bin/uv
 
 # Install system packages only needed for building dependencies.
 COPY scripts/install-dependency-packages.sh .

--- a/data/sample.lp
+++ b/data/sample.lp
@@ -1,0 +1,5 @@
+cpu,host=server01,region=us-west,env=prod usage_user=12.5,usage_system=4.2 1713571200000000000
+cpu,host=server02,region=us-east,env=staging usage_user=8.1,usage_system=2.9 1713571205000000000
+memory,host=server01,region=us-west,env=prod used=734003200i,free=2147483648i 1713571210000000000
+disk,host=server03,region=eu-central,env=prod,device=sda1 used_percent=67.3 1713571215000000000
+network,host=server02,region=us-east,env=staging,interface=eth0 bytes_sent=123456i,bytes_recv=654321i 1713571220000000000

--- a/data/sample.lp
+++ b/data/sample.lp
@@ -1,3 +1,10 @@
+# INFLUXDB EXPORT: 1677-09-21T00:12:43Z - 2262-04-11T23:47:16Z
+# DDL
+CREATE DATABASE "target.metrics"
+# DML
+# CONTEXT-DATABASE:target.metrics
+# CONTEXT-RETENTION-POLICY:forever
+# writing tsm data
 cpu,host=server01,region=us-west,env=prod usage_user=12.5,usage_system=4.2 1713571200000000000
 cpu,host=server02,region=us-east,env=staging usage_user=8.1,usage_system=2.9 1713571205000000000
 memory,host=server01,region=us-west,env=prod used=734003200i,free=2147483648i 1713571210000000000

--- a/docs/admin/backups.rst
+++ b/docs/admin/backups.rst
@@ -122,7 +122,7 @@ This creates a deployment that mounts the backup volume giving you access to the
 
 .. note::
 
-  Because the backup volume is ReadWriteOnce (RWO), before enabling the restore deployment make sure you temporarily supend the execution of the backup CronJob.
+  Because the backup volume is ReadWriteOnce (RWO), before enabling the restore deployment make sure you temporarily suspend the execution of the backup CronJob.
 
 
 Restoring from a Chronograf backup
@@ -207,10 +207,10 @@ For long-running restores, define a Kubernetes Job:
          volumes:
          - name: backup
            persistentVolumeClaim:
-             claimName: sasquatch-backup
+             claimName: sasquatch-backup-artifacts
          containers:
          - name: sasquatch-backup
-           image: ghcr.io/lsst-sqre/sasquatch-backup:1.3.0
+           image: ghcr.io/lsst-sqre/sasquatch-backup:1.4.0
            imagePullPolicy: IfNotPresent
            volumeMounts:
            - name: backup

--- a/docs/admin/cli.rst
+++ b/docs/admin/cli.rst
@@ -1,0 +1,12 @@
+.. _cli:
+
+#############
+CLI reference
+#############
+
+The ``sasquatch`` command line tool provides line protocol utilities and
+InfluxDB migration commands for administrators and operators.
+
+.. click:: sasquatch.cli:main
+   :prog: sasquatch
+   :nested: full

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -33,3 +33,8 @@ A Sasquatch administrator is responsible for maintaining the Sasquatch component
 
    request-exceeded-time-limit-error
    context-deadline-exceeded-error
+
+.. toctree::
+   :caption: Reference
+
+   cli

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -22,6 +22,7 @@ A Sasquatch administrator is responsible for maintaining the Sasquatch component
    managing-shards
    adding-subcharts
    backups
+   influxdb-migration
    monitoring
    query-limits
    license

--- a/docs/admin/influxdb-migration.rst
+++ b/docs/admin/influxdb-migration.rst
@@ -1,0 +1,458 @@
+.. _influxdb-migration:
+
+###########################
+InfluxDB database migration
+###########################
+
+This guide describes how to migrate an InfluxDB database from a Sasquatch
+backup with the ``sasquatch influxdb migrate`` commands.
+
+A typical use case is changing the database schema, for example dropping or renaming an InfluxDB measurement, tag, or field.
+
+Another use case is fixing series cardinality issues in InfluxDB.
+This involves changing the database schema, for example, dropping tags that have too many values and converting them into fields if possible.
+
+In these situations, the challenge is to migrate the historical data from an old database (old schema) to the new database (new schema).
+There is no official tool for doing such database migrations, and the community consensus is basically to export the database to line protocol format, transform the data and re-import it.
+
+The ``sasquatch influxdb migrate`` commands can also be used to migrate data from one InfluxDB server to another. However, if you are not changing the database schema and just want to copy data from one InfluxDB server to another, consider using the InfluxDB backup/restore tools  instead of the migration workflow described here. The backup/restore tools are more efficient than working with line protocol files.
+
+The database migration workflow as implemented in Sasquatch has four phases:
+
+#. Discover the TSM files to migrate from a database backup.
+#. Export those TSM files to line protocol.
+#. Transform the exported line protocol files if needed.
+#. Import the transformed data into the target InfluxDB instance.
+
+.. note::
+
+  Keep in mind that the import phase will write data into an existing database.
+  Make sure that you are importing into the correct database to prevent accidental
+  imports. If there are any transformations in the migration plan that change the
+  database schema, use the ``--target-database`` option during import to specify
+  a different database than the source database.
+
+
+Running migration commands
+==========================
+
+You can manually run migration commands.
+To run a migration, first you need to enable the migration deployment in
+``values-<environment>.yaml``:
+
+.. code-block:: yaml
+
+  influxdb-migration:
+    enabled: true
+
+This creates a deployment that mounts the backup volume, giving you access
+to the backup files in the ``/backup`` directory.
+
+You can exec into the migration Pod:
+
+.. code-block:: bash
+
+   kubectl exec -it <sasquatch migration pod> -n sasquatch -- /bin/sh
+
+
+Discover source shards
+======================
+
+Start by creating a migration run directory and discovering the shards you
+want to migrate:
+
+.. code-block:: bash
+
+   $ sasquatch influxdb migrate discover --backup-dir /backup/sasquatch-influxdb-oss-full-20260424T050007Z --database lsst.square.metrics --retention autogen --run-dir /backup/test-migration-1 --shard 986 --shard 997 --shard 1052
+   Discovered 8 TSM file(s) in 3 shard(s).
+
+.. note::
+
+   In a typical migration, use ``--all-shards`` during discovery so
+   Sasquatch reads the backup manifest and includes every shard for the
+   selected database and retention policy. This example uses repeated
+   ``--shard`` options only to illustrate how to migrate a small, explicit
+   shard subset.
+
+Check the migration status:
+
+.. code-block:: text
+
+   $ sasquatch influxdb migrate status --run-dir /backup/test-migration-1/
+   Migration run: lsst.square.metrics / autogen
+   Run ID: b0becae5428e
+   Backup: sasquatch-influxdb-oss-full-20260424T050007Z
+   Mode: explicit
+   Manifest status: discovered
+   Created: 2026-05-04T18:33:21.855030+00:00
+   Updated: 2026-05-04T18:33:21.855287+00:00
+
+   Overall:
+     Shards: 3
+     Files: 8
+     Exported: 0/8
+     Transformed: 0/8
+     Imported: 0/8
+     Error files: 0
+
+   Shard progress:
+     Shard  Files  Exported  Transformed  Imported  State
+     986    1/1    0/1         0/1            0/1         discovered
+     997    1/1    0/1         0/1            0/1         discovered
+     1052   6/6    0/6         0/6            0/6         discovered
+
+
+Export to line protocol
+=======================
+
+Export the discovered TSM files into line protocol files under the run
+directory:
+
+.. code-block:: bash
+
+   $ sasquatch influxdb migrate export --run-dir /backup/test-migration-1/
+   Exported 8 file(s).
+
+.. note::
+
+   Use ``--force`` with ``sasquatch influxdb migrate export`` to re-export
+   files that are already marked as exported in the manifest. This is useful
+   when you want to regenerate line protocol files in an existing run
+   directory.
+
+.. code-block:: text
+
+   $ sasquatch influxdb migrate status --run-dir /backup/test-migration-1/
+   Migration run: lsst.square.metrics / autogen
+   Run ID: b0becae5428e
+   Backup: sasquatch-influxdb-oss-full-20260424T050007Z
+   Mode: explicit
+   Manifest status: exported
+   Created: 2026-05-04T18:33:21.855030+00:00
+   Updated: 2026-05-04T18:35:49.770125+00:00
+
+   Overall:
+     Shards: 3
+     Files: 8
+     Exported: 8/8
+     Transformed: 0/8
+     Imported: 0/8
+     Error files: 0
+
+   Shard progress:
+     Shard  Files  Exported  Transformed  Imported  State
+     986    1/1    1/1         0/1            0/1         exported
+     997    1/1    1/1         0/1            0/1         exported
+     1052   6/6    6/6         0/6            0/6         exported
+
+The export phase produces line protocol only, so the exported files are ready
+for inspection and transformation before import.
+
+
+Inspect exported data
+=====================
+
+Use the ``line-protocol`` commands to inspect one of the exported files.
+For example, to show the tag keys present in one file:
+
+.. code-block:: bash
+
+   $ sasquatch influxdb line-protocol show-tags test-migration-1/1052/000000001-000000001.lp
+
+.. code-block:: text
+
+   lsst.square.metrics.events.gafaelfawr.active_user_sessions: application
+   lsst.square.metrics.events.gafaelfawr.active_user_tokens: application
+   lsst.square.metrics.events.gafaelfawr.auth_bot: application, service, username
+   lsst.square.metrics.events.gafaelfawr.login_attempt: application
+   lsst.square.metrics.events.gafaelfawr.rate_limit: application, service, username
+   lsst.square.metrics.events.mobu.muster: application, business, flock, success, username
+   lsst.square.metrics.events.mobu.notebook_cell_execution: application, business, flock, notebook, repo, success, username
+   lsst.square.metrics.events.mobu.notebook_execution: application, business, flock, notebook, repo, success, username
+   lsst.square.metrics.events.mobu.nublado_delete_: application, business, flock, success, username
+   lsst.square.metrics.events.mobu.nublado_spawn_lab: application, business, flock, success, username
+   lsst.square.metrics.events.mobu.sia_query: application, business, flock, success, username
+   lsst.square.metrics.events.mobu.tap_query: application, business, flock, success, sync, username
+   lsst.square.metrics.events.noteburst.arq_job_run: application, queue
+   lsst.square.metrics.events.noteburst.arq_queue_stats: application, queue
+   lsst.square.metrics.events.nublado.active_labs: application
+   lsst.square.metrics.events.nublado.spawn_success: application, username
+   lsst.square.metrics.events.qservkafka.arq_job_run: application, queue
+   lsst.square.metrics.events.qservkafka.arq_queue_stats: application, queue
+   lsst.square.metrics.events.qservkafka.qserv_failure: application
+   lsst.square.metrics.events.qservkafka.qserv_success: application, username
+   lsst.square.metrics.events.wobbly.completed: application, service, username
+   lsst.square.metrics.events.wobbly.created: application, service, username
+   lsst.square.metrics.events.wobbly.queued: application, service, username
+
+
+Transform exported files
+========================
+
+Create a transform plan to adjust the exported line protocol files before
+import.
+
+The ``sasquatch influxdb line-protocol`` implements the following operations to define a transform plan:
+
+- ``convert-tag-to-field``:  Convert a tag key and value into a string field.
+- ``drop-field``:            Drop a field key from a line protocol file.
+- ``drop-measurement``:      Drop a measurement from a line protocol file.
+- ``drop-tag``:              Drop a tag key from a line protocol file.
+- ``rename-field``:          Rename a field key in a line protocol file.
+- ``rename-measurement``:    Rename a measurement in a line protocol file.
+- ``rename-tag``:            Rename a tag key in a line protocol file.
+
+For example, the following plan drops the ``flock`` tag, renames the
+``application`` tag to ``app``, and drops the
+``lsst.square.metrics.events.qservkafka.query_failure`` measurement:
+
+.. code-block:: bash
+
+   cat <<EOF > plan.yaml
+   - op: drop-tag
+     tag: flock
+
+   - op: rename-tag
+     from: application
+     to: app
+
+   - op: drop-measurement
+     measurement: lsst.square.metrics.events.qservkafka.query_failure
+   EOF
+
+Apply the transform plan:
+
+.. code-block:: bash
+
+   $ sasquatch influxdb migrate transform --run-dir test-migration-1/ --plan plan.yaml
+   Transformed 8 file(s).
+
+.. code-block:: text
+
+   $ sasquatch influxdb migrate status --run-dir /backup/test-migration-1/
+   Migration run: lsst.square.metrics / autogen
+   Run ID: b0becae5428e
+   Backup: sasquatch-influxdb-oss-full-20260424T050007Z
+   Mode: explicit
+   Manifest status: transformed
+   Created: 2026-05-04T18:33:21.855030+00:00
+   Updated: 2026-05-04T18:46:58.680591+00:00
+
+   Overall:
+     Shards: 3
+     Files: 8
+     Exported: 8/8
+     Transformed: 8/8
+     Imported: 0/8
+     Error files: 0
+
+   Shard progress:
+     Shard  Files  Exported  Transformed  Imported  State
+     986    1/1    1/1         1/1            0/1         transformed
+     997    1/1    1/1         1/1            0/1         transformed
+     1052   6/6    6/6         6/6            0/6         transformed
+
+
+Import into the target database
+===============================
+
+Before importing, make sure the destination database already exists in the
+target InfluxDB server.
+The import phase rewrites the DML headers in each file
+and verifies that the target database named in ``# CONTEXT-DATABASE`` exists before
+calling ``influx -import``.
+
+.. note::
+
+   The ``influx -import`` command will import line protocol files into the specified target database.
+   Typically the target database is different from the source database, specially if you are transforming the data.
+   Always double check the ``--host`` and ``--target-database`` options to prevent accidental
+   imports into the wrong database. In the example below, the target database name is the same as the source
+   database ``lsst.square.metrics`` but the migration is to different InfluxDB server ``--host sasquatch-influxdb-enterprise-data``.
+
+
+Run the import:
+
+.. code-block:: bash
+
+   $ sasquatch influxdb migrate import --run-dir test-migration-1/ --host sasquatch-influxdb-enterprise-data --port 8086 --username admin --password <password> --target-database lsst.square.metrics
+
+.. note::
+
+   Use ``--force`` with ``sasquatch influxdb migrate import`` to re-import
+   files that are already marked as imported in the manifest. This is useful
+   when you need to rerun the import phase for an existing migration run.
+
+Check the final status:
+
+.. code-block:: text
+
+   $ sasquatch influxdb migrate status --run-dir test-migration-1/
+   Migration run: lsst.square.metrics / autogen
+   Run ID: b0becae5428e
+   Backup: sasquatch-influxdb-oss-full-20260424T050007Z
+   Mode: explicit
+   Manifest status: imported
+   Created: 2026-05-04T18:33:21.855030+00:00
+   Updated: 2026-05-05T17:03:12.387941+00:00
+
+   Overall:
+     Shards: 3
+     Files: 8
+     Exported: 8/8
+     Transformed: 8/8
+     Imported: 8/8
+     Error files: 0
+
+   Shard progress:
+     Shard  Files  Exported  Transformed  Imported  State
+     986    1/1    1/1         1/1            1/1         imported
+     997    1/1    1/1         1/1            1/1         imported
+     1052   6/6    6/6         6/6            6/6         imported
+
+
+Creating a migration Job
+========================
+
+For long-running migrations, define a Kubernetes Job instead of running the
+commands interactively in the migration Pod.
+The following example uses the Sasquatch application image and mounts the
+Sasquatch backup persistent volume at ``/backup``.
+That mount gives the Job
+access both to the backup directory and to a run
+directory under the same volume.
+
+.. note::
+
+  Because the backup volume is ReadWriteOnce (RWO), before applying the migration deployment make sure other Pods are not using the backup volume.
+
+It also mounts a ConfigMap containing ``plan.yaml`` so the transform phase
+can read the plan from the container filesystem.
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: sasquatch-migration-plan
+     namespace: sasquatch
+   data:
+     plan.yaml: |
+       - op: drop-tag
+         tag: flock
+
+       - op: rename-tag
+         from: application
+         to: app
+
+       - op: drop-measurement
+         measurement: lsst.square.metrics.events.qservkafka.query_failure
+   ---
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: sasquatch-migration-job
+     namespace: sasquatch
+   spec:
+     template:
+       spec:
+         restartPolicy: Never
+         securityContext:
+           runAsNonRoot: true
+           runAsUser: 1000
+           runAsGroup: 1000
+           fsGroup: 1000
+         volumes:
+         - name: backup
+           persistentVolumeClaim:
+             claimName: sasquatch-backup-artifacts
+         - name: migration-plan
+           configMap:
+             name: sasquatch-migration-plan
+         containers:
+         - name: sasquatch-migration
+           image: ghcr.io/lsst-sqre/sasquatch:1.4.0
+           imagePullPolicy: IfNotPresent
+           env:
+           - name: SASQUATCH_INFLUXDB_USER
+             valueFrom:
+               secretKeyRef:
+                 name: sasquatch
+                 key: influxdb-user
+           - name: SASQUATCH_INFLUXDB_PASSWORD
+             valueFrom:
+               secretKeyRef:
+                 name: sasquatch
+                 key: influxdb-password
+           volumeMounts:
+           - name: backup
+             mountPath: /backup
+           - name: migration-plan
+             mountPath: /etc/sasquatch-migration-plan
+             readOnly: true
+           command:
+           - /bin/sh
+           - -c
+           - >
+             sasquatch influxdb migrate discover
+             --backup-dir /backup/sasquatch-influxdb-oss-full-20260424T050007Z
+             --database lsst.square.metrics
+             --retention autogen
+             --run-dir /backup/migration-20260424T050007Z
+             --all-shards &&
+             sasquatch influxdb migrate export
+             --verify
+             --run-dir /backup/migration-20260424T050007Z &&
+             sasquatch influxdb migrate transform
+             --run-dir /backup/migration-20260424T050007Z
+             --plan /etc/sasquatch-migration-plan/plan.yaml &&
+             sasquatch influxdb migrate import
+             --run-dir /backup/migration-20260424T050007Z
+             --host sasquatch-influxdb-enterprise-data
+             --port 8086
+             --username "${SASQUATCH_INFLUXDB_USER}"
+             --password "${SASQUATCH_INFLUXDB_PASSWORD}"
+             --target-database lsst.square.metrics
+     backoffLimit: 0
+
+Save the manifest as ``migration-job.yaml`` and apply it:
+
+.. code-block:: bash
+
+   kubectl apply -f migration-job.yaml
+
+Update the example command sequence as needed for your migration.
+For example, you might want to run the discover and export phases in one Job and run the transform and import phases in another Job, so you can inspect the exported line protocol files before applying the transform and import steps.
+
+Operational notes
+=================
+
+- Use one run directory per migration attempt.
+- Monitor the Job logs to track the progress of the migration and check for any errors.
+
+.. code-block:: bash
+
+  kubectl logs job/sasquatch-migration-job -n sasquatch
+
+- Monitor the overall progress of the migration.
+
+.. code-block:: bash
+
+  kubectl exec -it <sasquatch migration pod> -n sasquatch -- sasquatch influxdb migrate status --run-dir <run-dir>
+
+- Exported and transformed files remain in the run directory, so you can
+  inspect them before import or rerun later phases with ``--force`` option as needed.
+
+Known edge cases
+================
+
+- Some exports may contain multiline string field values. Those records can be produced
+  directly by ``influx_inspect export`` and are not safe to import through
+  ``influx -import``, which expects one point per line.
+  Use ``sasquatch influxdb migrate export --run-dir <run-dir> --verify`` to
+  scan exported files and fail early with the file name and measurement if
+  this edge case is present.
+- ``drop-field`` deletes the entire record line when removing the last field in a point.
+  That's the correct choice for InfluxDB line protocol, since a point with zero fields is not valid.
+- In the import phase the ``influx -host`` option only accepts hostname and not a URL with subpath like ``https://usdf-rsp.slac.stanford.edu/influxdb-enterprise-data`` for the target InfluxDB server. An nginx reverse proxy can be used to work around this limitation.
+  See the Sasquatch ``influxb-migration`` subchart in Phalanx for an example of this setup.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,8 @@ linkcheck_ignore = [
     r"https://usdf-rsp-dev.slac.stanford.edu/.*",
     r"https://usdf-rsp-int.slac.stanford.edu/.*",
     r"https://usdf-rsp.slac.stanford.edu/.*",
+    r"https://strimzi.io/.*",
 ]
 
-linkcheck_rate_limit_timeout = 300
-linkcheck_retries = 1
+linkcheck_rate_limit_timeout = 30
+linkcheck_retries = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 from documenteer.conf.guide import *  # noqa
 
+extensions.append("sphinx_click")
+
 exclude_patterns = ["_rst_epilog.rst", "**.ipynb"]
 nb_execution_mode = "off"
 

--- a/migrations/lsst-prompt-migration-import-job.yaml
+++ b/migrations/lsst-prompt-migration-import-job.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sasquatch-migration-import-job
+  namespace: sasquatch
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      volumes:
+      - name: backup
+        persistentVolumeClaim:
+          claimName: sasquatch-backup-artifacts
+      - name: nginx-config
+        configMap:
+          name: influxdb-nginx-proxy
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: nginx-tmp
+        emptyDir: {}
+      containers:
+      - name: nginx-proxy
+        image: nginx:alpine
+        ports:
+          - containerPort: 8086
+        volumeMounts:
+          - name: nginx-config
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+          - mountPath: /var/cache/nginx
+            name: nginx-cache
+          - mountPath: /var/run
+            name: nginx-run
+          - mountPath: /tmp
+            name: nginx-tmp
+      - name: sasquatch-migration
+        image: ghcr.io/lsst-sqre/sasquatch:tickets-DM-54806
+        imagePullPolicy: Always
+        env:
+        - name: SASQUATCH_INFLUXDB_USER
+          valueFrom:
+            secretKeyRef:
+              name: sasquatch
+              key: influxdb-user
+        - name: SASQUATCH_INFLUXDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sasquatch
+              key: influxdb-password
+        volumeMounts:
+        - name: backup
+          mountPath: /backup
+        command:
+        - /bin/sh
+        - -c
+        - >
+          sasquatch influxdb migrate import
+          --run-dir /backup/lsst.prompt-migration-1
+          --host localhost
+          --port 8086
+          --username "$SASQUATCH_INFLUXDB_USER"
+          --password "$SASQUATCH_INFLUXDB_PASSWORD"
+          --target-database lsst.prompt
+  backoffLimit: 0

--- a/migrations/lsst-prompt-migration-import-nginx-configmap.yaml
+++ b/migrations/lsst-prompt-migration-import-nginx-configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: influxdb-nginx-proxy
+data:
+  nginx.conf: |
+
+    pid /tmp/nginx.pid;
+
+    events {}
+
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+
+      server {
+        listen 8086;
+
+        location / {
+          proxy_pass https://usdf-rsp.slac.stanford.edu/influxdb-enterprise-data/;
+          proxy_set_header Host usdf-rsp.slac.stanford.edu;
+          proxy_ssl_server_name on;
+        }
+      }
+    }

--- a/migrations/lsst-prompt-migration-job.yaml
+++ b/migrations/lsst-prompt-migration-job.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sasquatch-migration-job
+  namespace: sasquatch
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      volumes:
+      - name: backup
+        persistentVolumeClaim:
+          claimName: sasquatch-backup-artifacts
+      - name: migration-plan
+        configMap:
+          name: sasquatch-migration-plan
+      containers:
+      - name: sasquatch-migration
+        image: ghcr.io/lsst-sqre/sasquatch:tickets-DM-54806
+        imagePullPolicy: Always
+        env:
+        - name: SASQUATCH_INFLUXDB_USER
+          valueFrom:
+            secretKeyRef:
+              name: sasquatch
+              key: influxdb-user
+        - name: SASQUATCH_INFLUXDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sasquatch
+              key: influxdb-password
+        volumeMounts:
+        - name: backup
+          mountPath: /backup
+        - name: migration-plan
+          mountPath: /etc/sasquatch-migration-plan
+          readOnly: true
+        command:
+        - /bin/sh
+        - -c
+        - >
+          sasquatch influxdb migrate discover
+          --backup-dir /backup/sasquatch-influxdb-oss-full-20260506T030009Z
+          --database lsst.prompt
+          --retention autogen
+          --run-dir /backup/lsst.prompt-migration-1
+          --all-shards &&
+          sasquatch influxdb migrate export --verify
+          --run-dir /backup/lsst.prompt-migration-1 &&
+          sasquatch influxdb migrate transform
+          --run-dir /backup/lsst.prompt-migration-1
+          --plan /etc/sasquatch-migration-plan/plan.yaml
+  backoffLimit: 0

--- a/migrations/lsst-prompt-migration-plan-configmap.yaml
+++ b/migrations/lsst-prompt-migration-plan-configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sasquatch-migration-plan
+  namespace: sasquatch
+data:
+  plan.yaml: |
+    - op: drop-tag
+      tag: visit
+    - op: drop-tag
+      tag: group
+    - op: drop-field
+      field: band
+    - op: drop-field
+      field: dataset_tag
+    - op: drop-field
+      field: detector
+    - op: drop-field
+      field: instrument
+    - op: drop-field
+      field: physical_filter
+    - op: drop-field
+      field: skymap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "fastapi>=0.100",
     "pydantic>2",
     "pydantic-settings>=2",
+    "PyYAML>=6",
     "safir>=5",
     "uvicorn[standard]>=0.34",
     ]
@@ -71,6 +72,7 @@ tox = [
 ]
 typing = [
     "mypy>=1.19",
+    "types-PyYAML",
 ]
 
 [tool.coverage.run]

--- a/src/sasquatch/fields.py
+++ b/src/sasquatch/fields.py
@@ -9,6 +9,7 @@ from .line_protocol import (
     _escape_tag_key,
     _extract_measurement_and_field_keys,
     _extract_measurement_from_series_key,
+    _is_metadata_line,
     _iter_field_ranges,
     _rewrite_file_in_place,
     _split_record_content,
@@ -25,8 +26,7 @@ def _drop_field_from_line(
     """Drop a field key from a single line of InfluxDB line protocol."""
     line_ending = "\n" if line.endswith("\n") else ""
     content = line.removesuffix(line_ending)
-    stripped_line = content.strip()
-    if not stripped_line or stripped_line.startswith("#"):
+    if _is_metadata_line(content):
         return line
 
     record_parts = _split_record_content(content)
@@ -70,8 +70,7 @@ def _rename_field_in_line(
     """Rename a field key in a single line of InfluxDB line protocol."""
     line_ending = "\n" if line.endswith("\n") else ""
     content = line.removesuffix(line_ending)
-    stripped_line = content.strip()
-    if not stripped_line or stripped_line.startswith("#"):
+    if _is_metadata_line(content):
         return line
 
     record_parts = _split_record_content(content)

--- a/src/sasquatch/influxdb.py
+++ b/src/sasquatch/influxdb.py
@@ -18,14 +18,22 @@ def influxdb() -> None:
     """InfluxDB tools."""
 
 
-influxdb.add_command(show_tags)
-influxdb.add_command(show_fields)
-influxdb.add_command(drop_tag)
-influxdb.add_command(drop_field)
-influxdb.add_command(rename_tag)
-influxdb.add_command(rename_field)
-influxdb.add_command(show_measurements)
-influxdb.add_command(drop_measurement_command)
-influxdb.add_command(rename_measurement_command)
-influxdb.add_command(convert_tag_to_field_command)
+@click.group("line-protocol")
+def line_protocol() -> None:
+    """Line protocol inspection and rewrite tools."""
+
+
+line_protocol.add_command(show_tags)
+line_protocol.add_command(show_fields)
+line_protocol.add_command(drop_tag)
+line_protocol.add_command(drop_field)
+line_protocol.add_command(rename_tag)
+line_protocol.add_command(rename_field)
+line_protocol.add_command(show_measurements)
+line_protocol.add_command(drop_measurement_command)
+line_protocol.add_command(rename_measurement_command)
+line_protocol.add_command(convert_tag_to_field_command)
+
+
+influxdb.add_command(line_protocol)
 influxdb.add_command(migrate)

--- a/src/sasquatch/influxdb.py
+++ b/src/sasquatch/influxdb.py
@@ -8,6 +8,7 @@ from .measurements import (
     rename_measurement_command,
     show_measurements,
 )
+from .migration import migrate
 from .tag_to_field import convert_tag_to_field_command
 from .tags import drop_tag, rename_tag, show_tags
 
@@ -27,3 +28,4 @@ influxdb.add_command(show_measurements)
 influxdb.add_command(drop_measurement_command)
 influxdb.add_command(rename_measurement_command)
 influxdb.add_command(convert_tag_to_field_command)
+influxdb.add_command(migrate)

--- a/src/sasquatch/line_protocol.py
+++ b/src/sasquatch/line_protocol.py
@@ -69,6 +69,12 @@ def _unescape_if_needed(value: str) -> str:
     return _unescape(value) if "\\" in value else value
 
 
+def _is_metadata_line(line: str) -> bool:
+    """Return whether a line is header metadata, not line protocol data."""
+    stripped = line.strip()
+    return not stripped or stripped.startswith(("#", "CREATE "))
+
+
 def _escape_tag_key(value: str) -> str:
     """Escape a tag key for line protocol output."""
     escaped = value.replace("\\", "\\\\")
@@ -169,8 +175,7 @@ def _extract_measurement_and_tag_keys(  # noqa: C901, PLR0912, PLR0915
     line: str,
 ) -> tuple[str, set[str]] | None:
     """Extract a measurement name and tag keys with one pass over the line."""
-    stripped_line = line.lstrip()
-    if not stripped_line or stripped_line.startswith("#"):
+    if _is_metadata_line(line):
         return None
 
     measurement_chars: list[str] = []
@@ -240,8 +245,7 @@ def _extract_measurement_and_field_keys(
 ) -> tuple[str, set[str]] | None:
     """Extract a measurement name and field keys with one pass over fields."""
     content = line.rstrip("\n")
-    stripped_line = content.lstrip()
-    if not stripped_line or stripped_line.startswith("#"):
+    if _is_metadata_line(content):
         return None
 
     record_parts = _split_record_content(content)

--- a/src/sasquatch/measurements.py
+++ b/src/sasquatch/measurements.py
@@ -11,6 +11,7 @@ from .line_protocol import (
     _extract_measurement_and_tag_keys,
     _extract_measurement_from_series_key,
     _find_unescaped_separator,
+    _is_metadata_line,
     _rewrite_file_in_place,
 )
 
@@ -19,8 +20,7 @@ def _drop_measurement_from_line(line: str, measurement_to_drop: str) -> str:
     """Drop a measurement from a single line of InfluxDB line protocol."""
     line_ending = "\n" if line.endswith("\n") else ""
     content = line.removesuffix(line_ending)
-    stripped_line = content.strip()
-    if not stripped_line or stripped_line.startswith("#"):
+    if _is_metadata_line(content):
         return line
 
     field_separator = _find_unescaped_separator(content, " ")
@@ -43,8 +43,7 @@ def _rename_measurement_in_line(
     """Rename a measurement in a single line of InfluxDB line protocol."""
     line_ending = "\n" if line.endswith("\n") else ""
     content = line.removesuffix(line_ending)
-    stripped_line = content.strip()
-    if not stripped_line or stripped_line.startswith("#"):
+    if _is_metadata_line(content):
         return line
 
     field_separator = _find_unescaped_separator(content, " ")

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -13,6 +13,12 @@ from pathlib import Path
 from typing import Any
 
 import click
+import yaml
+
+from .fields import drop_measurement_field_key, rename_measurement_field_key
+from .measurements import drop_measurement, rename_measurement
+from .tag_to_field import TagToFieldConflictError, convert_tag_to_field
+from .tags import drop_measurement_tag_key, rename_measurement_tag_key
 
 
 def _utc_now() -> str:
@@ -116,6 +122,8 @@ class MigrationManifest:
     created_at: str
     updated_at: str
     status: str
+    transform_plan_path: str | None = None
+    transform_plan_hash: str | None = None
     files: list[MigrationFileRecord] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
@@ -154,6 +162,8 @@ def _load_manifest(
             created_at=data["created_at"],
             updated_at=data["updated_at"],
             status=data["status"],
+            transform_plan_path=data.get("transform_plan_path"),
+            transform_plan_hash=data.get("transform_plan_hash"),
             files=[
                 MigrationFileRecord(**record)
                 for record in data.get("files", [])
@@ -322,6 +332,198 @@ def _write_export_log(
         ),
         encoding="utf-8",
     )
+
+
+def _required_string(operation: dict[str, Any], key: str) -> str:
+    """Return a required string field from a transform operation."""
+    value = operation.get(key)
+    if not isinstance(value, str) or not value:
+        raise click.ClickException(
+            f"Transform operation {operation.get('op')!r} requires {key!r}."
+        )
+    return value
+
+
+def _operation_keys(op_name: str) -> list[str]:
+    """Return required keys for one transform operation."""
+    required_keys = {
+        "drop-tag": ["tag"],
+        "rename-tag": ["from", "to"],
+        "drop-field": ["field"],
+        "rename-field": ["from", "to"],
+        "drop-measurement": ["measurement"],
+        "rename-measurement": ["from", "to"],
+        "convert-tag-to-field": ["tag"],
+    }
+    try:
+        return required_keys[op_name]
+    except KeyError as exc:
+        raise click.ClickException(
+            f"Unknown transform operation {op_name!r}."
+        ) from exc
+
+
+def _normalize_operation(operation: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one transform operation for execution and hashing."""
+    op_name = operation.get("op")
+    if not isinstance(op_name, str):
+        raise click.ClickException(
+            "Each transform entry must define string 'op'."
+        )
+
+    measurement = operation.get("measurement")
+    if measurement is not None and not isinstance(measurement, str):
+        raise click.ClickException("Optional 'measurement' must be a string.")
+
+    normalized: dict[str, Any] = {"op": op_name}
+    if measurement is not None:
+        normalized["measurement"] = measurement
+
+    for key in _operation_keys(op_name):
+        normalized[key] = _required_string(operation, key)
+
+    return normalized
+
+
+def _load_transform_plan(plan_path: Path) -> tuple[list[dict[str, Any]], str]:
+    """Load and normalize a YAML transform plan."""
+    if plan_path.suffix.lower() not in {".yaml", ".yml"}:
+        raise click.UsageError(
+            "Transform plan must use a .yaml or .yml extension."
+        )
+
+    try:
+        raw_plan = yaml.safe_load(plan_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise click.ClickException(
+            f"Failed to parse YAML transform plan {plan_path}."
+        ) from exc
+
+    if not isinstance(raw_plan, list):
+        raise click.ClickException(
+            "Transform plan must be a list of operations."
+        )
+
+    normalized: list[dict[str, Any]] = []
+    for operation in raw_plan:
+        if not isinstance(operation, dict):
+            raise click.ClickException(
+                "Each transform plan entry must be an object."
+            )
+        normalized.append(_normalize_operation(operation))
+
+    plan_hash = hashlib.sha256(
+        json.dumps(normalized, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    return normalized, plan_hash
+
+
+def _apply_operation(file_path: Path, operation: dict[str, Any]) -> None:
+    """Apply one normalized transform operation to an LP file."""
+    op_name = operation["op"]
+    measurement = operation.get("measurement")
+
+    try:
+        if op_name == "drop-tag":
+            drop_measurement_tag_key(
+                file_path,
+                operation["tag"],
+                measurement=measurement,
+            )
+        elif op_name == "rename-tag":
+            rename_measurement_tag_key(
+                file_path,
+                operation["from"],
+                operation["to"],
+                measurement=measurement,
+            )
+        elif op_name == "drop-field":
+            drop_measurement_field_key(
+                file_path,
+                operation["field"],
+                measurement=measurement,
+            )
+        elif op_name == "rename-field":
+            rename_measurement_field_key(
+                file_path,
+                operation["from"],
+                operation["to"],
+                measurement=measurement,
+            )
+        elif op_name == "drop-measurement":
+            drop_measurement(file_path, operation["measurement"])
+        elif op_name == "rename-measurement":
+            rename_measurement(
+                file_path,
+                operation["from"],
+                operation["to"],
+            )
+        elif op_name == "convert-tag-to-field":
+            convert_tag_to_field(
+                file_path,
+                operation["tag"],
+                measurement=measurement,
+            )
+        else:  # pragma: no cover
+            raise click.ClickException(
+                f"Unsupported transform operation {op_name!r}."
+            )
+    except TagToFieldConflictError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _transform_files(
+    run_dir: Path,
+    manifest: MigrationManifest,
+    plan_path: Path,
+    *,
+    force: bool,
+) -> int:
+    """Apply a transform plan to exported line protocol files."""
+    if not manifest.files:
+        raise click.ClickException(
+            "No discovered files found in the manifest. Run export first."
+        )
+
+    normalized_plan, plan_hash = _load_transform_plan(plan_path)
+    if (
+        manifest.transform_plan_hash is not None
+        and manifest.transform_plan_hash != plan_hash
+        and any(record.transformed_at is not None for record in manifest.files)
+        and not force
+    ):
+        raise click.ClickException(
+            "Transform plan changed for an existing run. "
+            "Use --force to reapply it."
+        )
+
+    transformed_count = 0
+    for record in manifest.files:
+        export_lp_path = Path(record.export_lp_path)
+        if not export_lp_path.exists():
+            raise click.ClickException(
+                f"Exported file {export_lp_path} is missing. Run export first."
+            )
+        if record.transformed_at is not None and not force:
+            continue
+
+        try:
+            for operation in normalized_plan:
+                _apply_operation(export_lp_path, operation)
+        except click.ClickException as exc:
+            record.last_error = str(exc)
+            _save_manifest(run_dir, manifest)
+            raise
+
+        record.transformed_at = _utc_now()
+        record.last_error = None
+        transformed_count += 1
+
+    manifest.transform_plan_path = str(plan_path)
+    manifest.transform_plan_hash = plan_hash
+    manifest.status = "transformed"
+    _save_manifest(run_dir, manifest)
+    return transformed_count
 
 
 def _export_files(
@@ -508,6 +710,54 @@ def export_command(
     click.echo(f"Exported {exported_count} file(s).")
 
 
+@click.command("transform")
+@_common_run_options
+@click.option(
+    "--plan",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="YAML file describing ordered transform operations.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Reapply the transform plan to files already marked transformed.",
+)
+def transform_command(
+    backup_dir: Path,
+    database: str,
+    retention: str,
+    shards: tuple[str, ...],
+    work_dir: Path,
+    plan: Path,
+    *,
+    force: bool,
+) -> None:
+    """Transform exported line protocol files in place."""
+    normalized_shards = _stringify_shards(shards)
+    run_dir = _run_dir(
+        work_dir,
+        backup_dir,
+        database,
+        retention,
+        normalized_shards,
+    )
+    manifest = _load_manifest(
+        run_dir,
+        backup_dir,
+        database,
+        retention,
+        normalized_shards,
+    )
+    transformed_count = _transform_files(
+        run_dir,
+        manifest,
+        plan,
+        force=force,
+    )
+    click.echo(f"Transformed {transformed_count} file(s).")
+
+
 @click.group("migrate")
 def migrate() -> None:
     """Migration workflow commands for InfluxDB backups."""
@@ -515,3 +765,4 @@ def migrate() -> None:
 
 migrate.add_command(discover)
 migrate.add_command(export_command)
+migrate.add_command(transform_command)

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -106,6 +106,7 @@ class MigrationFileRecord:
     imported_at: str | None = None
     extracted_tsm_path: str | None = None
     export_log_path: str | None = None
+    import_log_path: str | None = None
     last_error: str | None = None
 
 
@@ -334,6 +335,111 @@ def _write_export_log(
     )
 
 
+def _write_import_log(
+    log_path: Path,
+    argv: list[str],
+    result: subprocess.CompletedProcess[str],
+) -> None:
+    """Write an import command log."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(
+        "\n".join(
+            [
+                f"argv: {' '.join(argv)}",
+                f"returncode: {result.returncode}",
+                "",
+                "stdout:",
+                result.stdout,
+                "",
+                "stderr:",
+                result.stderr,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _context_header_line(prefix: str, value: str) -> str:
+    """Build one DML context header line."""
+    return f"# {prefix}: {value}\n"
+
+
+def _find_import_context_indexes(
+    lines: list[str],
+) -> tuple[int | None, int | None, int | None, int | None]:
+    """Locate DML/context headers and the first data line."""
+    dml_index: int | None = None
+    database_index: int | None = None
+    retention_index: int | None = None
+    first_data_index: int | None = None
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            if stripped == "# DML":
+                dml_index = index
+            elif stripped.startswith("# CONTEXT-DATABASE:"):
+                database_index = index
+            elif stripped.startswith("# CONTEXT-RETENTION-POLICY:"):
+                retention_index = index
+            continue
+        if stripped:
+            first_data_index = index
+            break
+
+    return dml_index, database_index, retention_index, first_data_index
+
+
+def _replace_context_header(
+    lines: list[str],
+    index: int | None,
+    expected: str,
+) -> bool:
+    """Replace one existing header line if it differs."""
+    if index is None or lines[index] == expected:
+        return False
+    lines[index] = expected
+    return True
+
+
+def _insert_missing_context_headers(
+    lines: list[str],
+    *,
+    dml_index: int | None,
+    database_index: int | None,
+    retention_index: int | None,
+    first_data_index: int | None,
+    database: str,
+    retention: str,
+) -> bool:
+    """Insert any missing DML/context headers before the first data line."""
+    if (
+        dml_index is not None
+        and database_index is not None
+        and retention_index is not None
+    ):
+        return False
+
+    insert_at = (
+        first_data_index if first_data_index is not None else len(lines)
+    )
+    header_lines: list[str] = []
+    if dml_index is None:
+        header_lines.append("# DML\n")
+    if database_index is None:
+        header_lines.append(_context_header_line("CONTEXT-DATABASE", database))
+    if retention_index is None:
+        header_lines.append(
+            _context_header_line(
+                "CONTEXT-RETENTION-POLICY",
+                retention,
+            )
+        )
+    lines[insert_at:insert_at] = header_lines
+    return True
+
+
 def _required_string(operation: dict[str, Any], key: str) -> str:
     """Return a required string field from a transform operation."""
     value = operation.get(key)
@@ -526,6 +632,121 @@ def _transform_files(
     return transformed_count
 
 
+def _rewrite_import_context(
+    file_path: Path,
+    *,
+    database: str,
+    retention: str,
+) -> str | None:
+    """Rewrite or add import context headers in place."""
+    lines = file_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    (
+        dml_index,
+        database_index,
+        retention_index,
+        first_data_index,
+    ) = _find_import_context_indexes(lines)
+
+    modified = _replace_context_header(
+        lines,
+        database_index,
+        _context_header_line("CONTEXT-DATABASE", database),
+    )
+    modified = (
+        _replace_context_header(
+            lines,
+            retention_index,
+            _context_header_line("CONTEXT-RETENTION-POLICY", retention),
+        )
+        or modified
+    )
+    added = _insert_missing_context_headers(
+        lines,
+        dml_index=dml_index,
+        database_index=database_index,
+        retention_index=retention_index,
+        first_data_index=first_data_index,
+        database=database,
+        retention=retention,
+    )
+
+    if added or modified:
+        file_path.write_text("".join(lines), encoding="utf-8")
+
+    if added:
+        return "added"
+    if modified:
+        return "modified"
+    return None
+
+
+def _build_import_argv(
+    *,
+    file_path: Path,
+    host: str,
+    port: int,
+    username: str | None,
+    password: str | None,
+    precision: str,
+    pps: int,
+    compressed: bool,
+    ssl: bool,
+    unsafe_ssl: bool,
+) -> list[str]:
+    """Build the influx CLI argv for one file import."""
+    argv = [
+        "influx",
+        "-host",
+        host,
+        "-port",
+        str(port),
+        "-import",
+        "-path",
+        str(file_path),
+        "-precision",
+        precision,
+    ]
+    if username is not None:
+        argv.extend(["-username", username])
+    if password is not None:
+        argv.extend(["-password", password])
+    if pps:
+        argv.extend(["-pps", str(pps)])
+    if compressed:
+        argv.append("-compressed")
+    if ssl:
+        argv.append("-ssl")
+    if unsafe_ssl:
+        argv.append("-unsafeSsl")
+    return argv
+
+
+def _emit_import_context_message(
+    status: str | None,
+    *,
+    file_path: Path,
+    database: str,
+    retention: str,
+) -> None:
+    """Print a per-file header update message when needed."""
+    if status == "added":
+        click.echo(
+            f"Added import headers to {file_path} for "
+            f"database={database}, retention={retention}."
+        )
+    elif status == "modified":
+        click.echo(
+            f"Updated import headers in {file_path} to "
+            f"database={database}, retention={retention}."
+        )
+
+
+def _import_log_path(run_dir: Path, record: MigrationFileRecord) -> Path:
+    """Return the import log path for one file record."""
+    file_stem = Path(record.export_lp_path).stem
+    return run_dir / "logs" / "import" / f"{record.shard_id}-{file_stem}.log"
+
+
 def _export_files(
     run_dir: Path,
     manifest: MigrationManifest,
@@ -609,6 +830,91 @@ def _export_files(
     manifest.status = "exported"
     _save_manifest(run_dir, manifest)
     return exported_count
+
+
+def _import_files(
+    run_dir: Path,
+    manifest: MigrationManifest,
+    *,
+    target_database: str,
+    target_retention: str,
+    host: str,
+    port: int,
+    username: str | None,
+    password: str | None,
+    precision: str,
+    pps: int,
+    compressed: bool,
+    ssl: bool,
+    unsafe_ssl: bool,
+    force: bool,
+) -> int:
+    """Import transformed line protocol files."""
+    if not manifest.files:
+        raise click.ClickException(
+            "No discovered files found in the manifest. Run transform first."
+        )
+
+    imported_count = 0
+    for record in manifest.files:
+        file_path = Path(record.export_lp_path)
+        if not file_path.exists():
+            raise click.ClickException(
+                f"Line protocol file {file_path} is missing."
+            )
+        if record.transformed_at is None:
+            raise click.ClickException(
+                f"File {file_path} has not been transformed. "
+                "Run transform first."
+            )
+        if record.imported_at is not None and not force:
+            continue
+
+        rewrite_status = _rewrite_import_context(
+            file_path,
+            database=target_database,
+            retention=target_retention,
+        )
+        _emit_import_context_message(
+            rewrite_status,
+            file_path=file_path,
+            database=target_database,
+            retention=target_retention,
+        )
+        argv = _build_import_argv(
+            file_path=file_path,
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            precision=precision,
+            pps=pps,
+            compressed=compressed,
+            ssl=ssl,
+            unsafe_ssl=unsafe_ssl,
+        )
+
+        result = _run_external_command(argv)
+        log_path = _import_log_path(run_dir, record)
+        _write_import_log(log_path, argv, result)
+        record.import_log_path = str(log_path)
+
+        if result.returncode != 0:
+            record.last_error = (
+                result.stderr.strip() or "Import command failed."
+            )
+            _save_manifest(run_dir, manifest)
+            raise click.ClickException(
+                f"Failed to import {file_path}: {record.last_error}"
+            )
+
+        record.imported_at = _utc_now()
+        record.last_error = None
+        imported_count += 1
+
+    manifest.status = "imported"
+    _save_manifest(run_dir, manifest)
+    return imported_count
 
 
 def _common_run_options[F: Callable[..., Any]](function: F) -> F:
@@ -758,6 +1064,104 @@ def transform_command(
     click.echo(f"Transformed {transformed_count} file(s).")
 
 
+@click.command("import")
+@_common_run_options
+@click.option("--host", required=True, help="InfluxDB host name.")
+@click.option("--port", type=int, default=8086, show_default=True)
+@click.option("--username", default=None, help="InfluxDB username.")
+@click.option("--password", default=None, help="InfluxDB password.")
+@click.option(
+    "--target-database",
+    default=None,
+    help=(
+        "Destination database for the import. Defaults to the source "
+        "database recorded in the manifest."
+    ),
+)
+@click.option(
+    "--target-retention",
+    default=None,
+    help=(
+        "Destination retention policy for the import. Defaults to the "
+        "source retention recorded in the manifest."
+    ),
+)
+@click.option(
+    "--precision",
+    default="ns",
+    show_default=True,
+    type=click.Choice(["h", "m", "s", "ms", "u", "ns"]),
+)
+@click.option("--pps", type=int, default=0, show_default=True)
+@click.option("--compressed", is_flag=True)
+@click.option("--ssl", is_flag=True, help="Use HTTPS for the import request.")
+@click.option(
+    "--unsafe-ssl",
+    is_flag=True,
+    help="Disable SSL certificate verification.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Re-import files already marked imported in the manifest.",
+)
+def import_command(
+    backup_dir: Path,
+    database: str,
+    retention: str,
+    shards: tuple[str, ...],
+    work_dir: Path,
+    host: str,
+    port: int,
+    username: str | None,
+    password: str | None,
+    target_database: str | None,
+    target_retention: str | None,
+    precision: str,
+    pps: int,
+    *,
+    compressed: bool,
+    ssl: bool,
+    unsafe_ssl: bool,
+    force: bool,
+) -> None:
+    """Import transformed line protocol files into InfluxDB."""
+    normalized_shards = _stringify_shards(shards)
+    run_dir = _run_dir(
+        work_dir,
+        backup_dir,
+        database,
+        retention,
+        normalized_shards,
+    )
+    manifest = _load_manifest(
+        run_dir,
+        backup_dir,
+        database,
+        retention,
+        normalized_shards,
+    )
+    resolved_target_database = target_database or manifest.database
+    resolved_target_retention = target_retention or manifest.retention
+    imported_count = _import_files(
+        run_dir,
+        manifest,
+        target_database=resolved_target_database,
+        target_retention=resolved_target_retention,
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        precision=precision,
+        pps=pps,
+        compressed=compressed,
+        ssl=ssl,
+        unsafe_ssl=unsafe_ssl,
+        force=force,
+    )
+    click.echo(f"Imported {imported_count} file(s).")
+
+
 @click.group("migrate")
 def migrate() -> None:
     """Migration workflow commands for InfluxDB backups."""
@@ -766,3 +1170,4 @@ def migrate() -> None:
 migrate.add_command(discover)
 migrate.add_command(export_command)
 migrate.add_command(transform_command)
+migrate.add_command(import_command)

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import subprocess
 import tarfile
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import click
 
@@ -67,6 +70,22 @@ def _manifest_path(run_dir: Path) -> Path:
     return run_dir / "migration-manifest.json"
 
 
+def _run_dir(
+    work_dir: Path,
+    backup_dir: Path,
+    database: str,
+    retention: str,
+    shards: list[str],
+) -> Path:
+    """Return the working directory for one migration run."""
+    return work_dir / _run_dir_name(
+        backup_dir.name,
+        database,
+        retention,
+        shards,
+    )
+
+
 @dataclass
 class MigrationFileRecord:
     """Metadata for one discovered TSM file."""
@@ -79,6 +98,8 @@ class MigrationFileRecord:
     exported_at: str | None = None
     transformed_at: str | None = None
     imported_at: str | None = None
+    extracted_tsm_path: str | None = None
+    export_log_path: str | None = None
     last_error: str | None = None
 
 
@@ -247,7 +268,148 @@ def _discover_files(
     return len(manifest.files)
 
 
-def _common_run_options(function: object) -> object:
+def _extract_archive_member(
+    archive_path: Path,
+    member_name: str,
+    destination: Path,
+) -> None:
+    """Extract one TSM member from a shard archive."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, "r:gz") as archive:
+        extracted = archive.extractfile(member_name)
+        if extracted is None:
+            raise click.ClickException(
+                f"Could not extract {member_name!r} from {archive_path}."
+            )
+        destination.write_bytes(extracted.read())
+
+
+def _run_external_command(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run an external command and capture its output."""
+    try:
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"Required executable {argv[0]!r} was not found."
+        ) from exc
+
+
+def _write_export_log(
+    log_path: Path,
+    argv: list[str],
+    result: subprocess.CompletedProcess[str],
+) -> None:
+    """Write an export command log."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(
+        "\n".join(
+            [
+                f"argv: {' '.join(argv)}",
+                f"returncode: {result.returncode}",
+                "",
+                "stdout:",
+                result.stdout,
+                "",
+                "stderr:",
+                result.stderr,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _export_files(
+    run_dir: Path,
+    manifest: MigrationManifest,
+    *,
+    force: bool,
+) -> int:
+    """Export discovered TSM files to line protocol."""
+    if not manifest.files:
+        raise click.ClickException(
+            "No discovered files found in the manifest. Run discover first."
+        )
+
+    exported_count = 0
+    for record in manifest.files:
+        export_lp_path = Path(record.export_lp_path)
+        if (
+            record.exported_at is not None
+            and export_lp_path.exists()
+            and not force
+        ):
+            continue
+
+        extracted_tsm_path = (
+            run_dir
+            / "extracted-tsm"
+            / record.shard_id
+            / Path(record.archive_member_path).name
+        )
+        _extract_archive_member(
+            Path(record.archive_path),
+            record.archive_member_path,
+            extracted_tsm_path,
+        )
+
+        export_lp_path.parent.mkdir(parents=True, exist_ok=True)
+        argv = [
+            "influx_inspect",
+            "export",
+            "-database",
+            manifest.database,
+            "-retention",
+            manifest.retention,
+            "-lponly",
+            "-tsmfile",
+            str(extracted_tsm_path),
+            "-out",
+            str(export_lp_path),
+        ]
+        result = _run_external_command(argv)
+        log_path = (
+            run_dir
+            / "logs"
+            / "export"
+            / f"{record.shard_id}-{Path(record.archive_member_path).stem}.log"
+        )
+        _write_export_log(log_path, argv, result)
+        record.extracted_tsm_path = str(extracted_tsm_path)
+        record.export_log_path = str(log_path)
+
+        if result.returncode != 0:
+            record.last_error = (
+                result.stderr.strip() or "Export command failed."
+            )
+            _save_manifest(run_dir, manifest)
+            raise click.ClickException(
+                f"Failed to export {record.archive_member_path}: "
+                f"{record.last_error}"
+            )
+
+        if not export_lp_path.exists():
+            record.last_error = (
+                "Export completed without creating the LP file."
+            )
+            _save_manifest(run_dir, manifest)
+            raise click.ClickException(record.last_error)
+
+        record.exported_at = _utc_now()
+        record.last_error = None
+        exported_count += 1
+
+    manifest.status = "exported"
+    _save_manifest(run_dir, manifest)
+    return exported_count
+
+
+def _common_run_options[F: Callable[..., Any]](function: F) -> F:
     """Add shared migration-run options to a Click command."""
     function = click.option(
         "--work-dir",
@@ -282,8 +444,9 @@ def discover(
 ) -> None:
     """Discover TSM files for a migration run."""
     normalized_shards = _stringify_shards(shards)
-    run_dir = work_dir / _run_dir_name(
-        backup_dir.name,
+    run_dir = _run_dir(
+        work_dir,
+        backup_dir,
         database,
         retention,
         normalized_shards,
@@ -303,9 +466,52 @@ def discover(
     )
 
 
+@click.command("export")
+@_common_run_options
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Re-export files already marked exported in the manifest.",
+)
+def export_command(
+    backup_dir: Path,
+    database: str,
+    retention: str,
+    shards: tuple[str, ...],
+    work_dir: Path,
+    *,
+    force: bool,
+) -> None:
+    """Export discovered TSM files to line protocol."""
+    normalized_shards = _stringify_shards(shards)
+    run_dir = _run_dir(
+        work_dir,
+        backup_dir,
+        database,
+        retention,
+        normalized_shards,
+    )
+    manifest = _load_manifest(
+        run_dir,
+        backup_dir,
+        database,
+        retention,
+        normalized_shards,
+    )
+    if not manifest.files:
+        _discover_files(run_dir, manifest, backup_dir)
+    exported_count = _export_files(
+        run_dir,
+        manifest,
+        force=force,
+    )
+    click.echo(f"Exported {exported_count} file(s).")
+
+
 @click.group("migrate")
 def migrate() -> None:
     """Migration workflow commands for InfluxDB backups."""
 
 
 migrate.add_command(discover)
+migrate.add_command(export_command)

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -1,0 +1,311 @@
+"""Commands for InfluxDB migration workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tarfile
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+import click
+
+
+def _utc_now() -> str:
+    """Return the current UTC timestamp in ISO 8601 format."""
+    return datetime.now(tz=UTC).isoformat()
+
+
+def _stringify_shards(shards: tuple[str, ...]) -> list[str]:
+    """Normalize shard identifiers into non-empty strings."""
+    normalized = [str(shard).strip() for shard in shards if str(shard).strip()]
+    if not normalized:
+        raise click.UsageError("Provide at least one --shard value.")
+    return normalized
+
+
+def _run_id(
+    backup_name: str,
+    database: str,
+    retention: str,
+    shards: list[str],
+) -> str:
+    """Build a deterministic migration run identifier."""
+    payload = json.dumps(
+        {
+            "backup_name": backup_name,
+            "database": database,
+            "retention": retention,
+            "shards": sorted(shards),
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def _slugify(value: str) -> str:
+    """Create a filesystem-friendly slug."""
+    return "".join(
+        char if char.isalnum() or char in ".-_" else "_" for char in value
+    )
+
+
+def _run_dir_name(
+    backup_name: str,
+    database: str,
+    retention: str,
+    shards: list[str],
+) -> str:
+    """Return the per-run working directory name."""
+    run_id = _run_id(backup_name, database, retention, shards)
+    return f"{_slugify(database)}--{_slugify(retention)}--{run_id}"
+
+
+def _manifest_path(run_dir: Path) -> Path:
+    """Return the manifest path within a run directory."""
+    return run_dir / "migration-manifest.json"
+
+
+@dataclass
+class MigrationFileRecord:
+    """Metadata for one discovered TSM file."""
+
+    shard_id: str
+    archive_path: str
+    archive_member_path: str
+    export_lp_path: str
+    discovered_at: str
+    exported_at: str | None = None
+    transformed_at: str | None = None
+    imported_at: str | None = None
+    last_error: str | None = None
+
+
+@dataclass
+class MigrationManifest:
+    """Sidecar manifest for a migration run."""
+
+    run_id: str
+    backup_dir: str
+    backup_name: str
+    database: str
+    retention: str
+    shards: list[str]
+    created_at: str
+    updated_at: str
+    status: str
+    files: list[MigrationFileRecord] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the manifest to JSON-compatible data."""
+        return asdict(self)
+
+
+def _save_manifest(run_dir: Path, manifest: MigrationManifest) -> None:
+    """Write the manifest to disk."""
+    manifest.updated_at = _utc_now()
+    _manifest_path(run_dir).write_text(
+        json.dumps(manifest.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _load_manifest(
+    run_dir: Path,
+    backup_dir: Path,
+    database: str,
+    retention: str,
+    shards: list[str],
+) -> MigrationManifest:
+    """Load an existing manifest or initialize a new one."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = _manifest_path(run_dir)
+    if manifest_path.exists():
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest = MigrationManifest(
+            run_id=data["run_id"],
+            backup_dir=data["backup_dir"],
+            backup_name=data["backup_name"],
+            database=data["database"],
+            retention=data["retention"],
+            shards=list(data["shards"]),
+            created_at=data["created_at"],
+            updated_at=data["updated_at"],
+            status=data["status"],
+            files=[
+                MigrationFileRecord(**record)
+                for record in data.get("files", [])
+            ],
+        )
+        expected = {
+            "backup_dir": str(backup_dir),
+            "backup_name": backup_dir.name,
+            "database": database,
+            "retention": retention,
+            "shards": sorted(shards),
+        }
+        actual = {
+            "backup_dir": manifest.backup_dir,
+            "backup_name": manifest.backup_name,
+            "database": manifest.database,
+            "retention": manifest.retention,
+            "shards": sorted(manifest.shards),
+        }
+        if actual != expected:
+            raise click.ClickException(
+                "Existing migration manifest does not match "
+                "the supplied inputs."
+            )
+        return manifest
+
+    now = _utc_now()
+    return MigrationManifest(
+        run_id=_run_id(backup_dir.name, database, retention, shards),
+        backup_dir=str(backup_dir),
+        backup_name=backup_dir.name,
+        database=database,
+        retention=retention,
+        shards=sorted(shards),
+        created_at=now,
+        updated_at=now,
+        status="initialized",
+    )
+
+
+def _iter_shard_archives(backup_dir: Path, shard_id: str) -> list[Path]:
+    """Return archives that match one shard ID."""
+    return sorted(backup_dir.glob(f"*.s{shard_id}.tar.gz"))
+
+
+def _discover_shard_files(
+    backup_dir: Path,
+    database: str,
+    retention: str,
+    shard_id: str,
+) -> list[tuple[Path, str]]:
+    """Discover TSM files for one shard inside shard archives."""
+    discovered: list[tuple[Path, str]] = []
+    expected_prefix = f"{database}/{retention}/{shard_id}/"
+
+    for archive_path in _iter_shard_archives(backup_dir, shard_id):
+        with tarfile.open(archive_path, "r:gz") as archive:
+            for member in archive.getmembers():
+                if not member.isfile():
+                    continue
+                if not member.name.endswith(".tsm"):
+                    continue
+                if not member.name.startswith(expected_prefix):
+                    continue
+                discovered.append((archive_path, member.name))
+
+    return discovered
+
+
+def _discover_files(
+    run_dir: Path,
+    manifest: MigrationManifest,
+    backup_dir: Path,
+) -> int:
+    """Populate the manifest with discovered shard files."""
+    files: list[MigrationFileRecord] = []
+    for shard_id in manifest.shards:
+        discovered = _discover_shard_files(
+            backup_dir,
+            manifest.database,
+            manifest.retention,
+            shard_id,
+        )
+        if not discovered:
+            raise click.ClickException(
+                "No TSM files found for shard "
+                f"{shard_id!r} in the backup directory."
+            )
+
+        for archive_path, member_name in discovered:
+            tsm_stem = Path(member_name).stem
+            files.append(
+                MigrationFileRecord(
+                    shard_id=shard_id,
+                    archive_path=str(archive_path),
+                    archive_member_path=member_name,
+                    export_lp_path=str(run_dir / shard_id / f"{tsm_stem}.lp"),
+                    discovered_at=_utc_now(),
+                )
+            )
+
+    manifest.files = sorted(
+        files,
+        key=lambda record: (
+            record.shard_id,
+            record.archive_path,
+            record.archive_member_path,
+        ),
+    )
+    manifest.status = "discovered"
+    _save_manifest(run_dir, manifest)
+    return len(manifest.files)
+
+
+def _common_run_options(function: object) -> object:
+    """Add shared migration-run options to a Click command."""
+    function = click.option(
+        "--work-dir",
+        type=click.Path(file_okay=False, path_type=Path),
+        required=True,
+        help="Directory to store per-run manifests and migration artifacts.",
+    )(function)
+    function = click.option(
+        "--shard",
+        "shards",
+        multiple=True,
+        required=True,
+        help="Shard ID to include. Repeat for multiple shards.",
+    )(function)
+    function = click.option("--retention", required=True)(function)
+    function = click.option("--database", required=True)(function)
+    return click.option(
+        "--backup-dir",
+        type=click.Path(exists=True, file_okay=False, path_type=Path),
+        required=True,
+    )(function)
+
+
+@click.command("discover")
+@_common_run_options
+def discover(
+    backup_dir: Path,
+    database: str,
+    retention: str,
+    shards: tuple[str, ...],
+    work_dir: Path,
+) -> None:
+    """Discover TSM files for a migration run."""
+    normalized_shards = _stringify_shards(shards)
+    run_dir = work_dir / _run_dir_name(
+        backup_dir.name,
+        database,
+        retention,
+        normalized_shards,
+    )
+    manifest = _load_manifest(
+        run_dir,
+        backup_dir,
+        database,
+        retention,
+        normalized_shards,
+    )
+    discovered_count = _discover_files(run_dir, manifest, backup_dir)
+    click.echo(
+        "Discovered "
+        f"{discovered_count} TSM file(s) in "
+        f"{len(manifest.shards)} shard(s)."
+    )
+
+
+@click.group("migrate")
+def migrate() -> None:
+    """Migration workflow commands for InfluxDB backups."""
+
+
+migrate.add_command(discover)

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -789,7 +789,6 @@ def _export_files(
             manifest.database,
             "-retention",
             manifest.retention,
-            "-lponly",
             "-tsmfile",
             str(extracted_tsm_path),
             "-out",

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -154,6 +154,21 @@ class MigrationManifest:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class ShardProgress:
+    """Runtime-only progress summary for one shard."""
+
+    shard_id: str
+    file_count: int
+    exported_count: int
+    transformed_count: int
+    imported_count: int
+    error_count: int
+    state: str
+    latest_timestamp: str | None
+    errors: list[tuple[str, str]]
+
+
 def _save_manifest(run_dir: Path, manifest: MigrationManifest) -> None:
     """Write the manifest to disk."""
     manifest.updated_at = _utc_now()
@@ -161,6 +176,45 @@ def _save_manifest(run_dir: Path, manifest: MigrationManifest) -> None:
         json.dumps(manifest.to_dict(), indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def _load_manifest_from_run_dir(run_dir: Path) -> MigrationManifest:
+    """Load an existing manifest directly from a run directory."""
+    manifest_path = _manifest_path(run_dir)
+    if not manifest_path.exists():
+        raise click.ClickException(
+            f"No migration-manifest.json found in {run_dir}."
+        )
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(
+            f"Failed to parse manifest file {manifest_path}."
+        ) from exc
+
+    try:
+        return MigrationManifest(
+            run_id=data["run_id"],
+            backup_dir=data["backup_dir"],
+            backup_name=data["backup_name"],
+            database=data["database"],
+            retention=data["retention"],
+            all_shards=data.get("all_shards", False),
+            shards=list(data["shards"]),
+            created_at=data["created_at"],
+            updated_at=data["updated_at"],
+            status=data["status"],
+            transform_plan_path=data.get("transform_plan_path"),
+            transform_plan_hash=data.get("transform_plan_hash"),
+            files=[
+                MigrationFileRecord(**record)
+                for record in data.get("files", [])
+            ],
+        )
+    except (KeyError, TypeError) as exc:
+        raise click.ClickException(
+            f"Manifest file {manifest_path} is missing required fields."
+        ) from exc
 
 
 def _load_manifest(
@@ -780,6 +834,11 @@ def _transform_files(
             "Use --force to reapply it."
         )
 
+    manifest.transform_plan_path = str(plan_path)
+    manifest.transform_plan_hash = plan_hash
+    manifest.status = "transforming"
+    _save_manifest(run_dir, manifest)
+
     transformed_count = 0
     for record in manifest.files:
         export_lp_path = Path(record.export_lp_path)
@@ -800,10 +859,9 @@ def _transform_files(
 
         record.transformed_at = _utc_now()
         record.last_error = None
+        _save_manifest(run_dir, manifest)
         transformed_count += 1
 
-    manifest.transform_plan_path = str(plan_path)
-    manifest.transform_plan_hash = plan_hash
     manifest.status = "transformed"
     _save_manifest(run_dir, manifest)
     return transformed_count
@@ -924,6 +982,156 @@ def _import_log_path(run_dir: Path, record: MigrationFileRecord) -> Path:
     return run_dir / "logs" / "import" / f"{record.shard_id}-{file_stem}.log"
 
 
+def _group_records_by_shard(
+    records: list[MigrationFileRecord],
+) -> dict[str, list[MigrationFileRecord]]:
+    """Group manifest file records by shard identifier."""
+    grouped: dict[str, list[MigrationFileRecord]] = {}
+    for record in records:
+        grouped.setdefault(record.shard_id, []).append(record)
+    return grouped
+
+
+def _latest_file_timestamp(record: MigrationFileRecord) -> str | None:
+    """Return the latest known timestamp for a file record."""
+    for value in (
+        record.imported_at,
+        record.transformed_at,
+        record.exported_at,
+        record.discovered_at,
+    ):
+        if value is not None:
+            return value
+    return None
+
+
+def _summarize_shard_progress(
+    records: list[MigrationFileRecord],
+) -> ShardProgress:
+    """Build a shard progress summary from manifest file records."""
+    sorted_records = sorted(
+        records,
+        key=lambda record: Path(record.export_lp_path).name,
+    )
+    file_count = len(sorted_records)
+    exported_count = sum(
+        1 for record in sorted_records if record.exported_at is not None
+    )
+    transformed_count = sum(
+        1 for record in sorted_records if record.transformed_at is not None
+    )
+    imported_count = sum(
+        1 for record in sorted_records if record.imported_at is not None
+    )
+    errors: list[tuple[str, str]] = [
+        (Path(record.export_lp_path).name, record.last_error)
+        for record in sorted_records
+        if record.last_error is not None
+    ]
+    error_count = len(errors)
+    latest_timestamp = max(
+        [
+            timestamp
+            for record in sorted_records
+            if (timestamp := _latest_file_timestamp(record)) is not None
+        ],
+        default=None,
+    )
+
+    if error_count:
+        state = "error"
+    elif imported_count == file_count:
+        state = "imported"
+    elif transformed_count == file_count:
+        state = "transformed"
+    elif exported_count == file_count:
+        state = "exported"
+    elif exported_count == 0:
+        state = "discovered"
+    else:
+        state = "in-progress"
+
+    return ShardProgress(
+        shard_id=sorted_records[0].shard_id,
+        file_count=file_count,
+        exported_count=exported_count,
+        transformed_count=transformed_count,
+        imported_count=imported_count,
+        error_count=error_count,
+        state=state,
+        latest_timestamp=latest_timestamp,
+        errors=errors,
+    )
+
+
+def _render_status_report(manifest: MigrationManifest) -> str:
+    """Render a user-friendly progress report for one run manifest."""
+    grouped_records = _group_records_by_shard(manifest.files)
+    shard_progress = [
+        _summarize_shard_progress(records)
+        for _shard_id, records in sorted(
+            grouped_records.items(),
+            key=lambda item: int(item[0]) if item[0].isdigit() else item[0],
+        )
+    ]
+    total_files = len(manifest.files)
+    total_exported = sum(
+        progress.exported_count for progress in shard_progress
+    )
+    total_transformed = sum(
+        progress.transformed_count for progress in shard_progress
+    )
+    total_imported = sum(
+        progress.imported_count for progress in shard_progress
+    )
+    total_errors = sum(progress.error_count for progress in shard_progress)
+
+    lines = [
+        f"Migration run: {manifest.database} / {manifest.retention}",
+        f"Run ID: {manifest.run_id}",
+        f"Backup: {manifest.backup_name}",
+        f"Mode: {'all-shards' if manifest.all_shards else 'explicit'}",
+        f"Manifest status: {manifest.status}",
+        f"Created: {manifest.created_at}",
+        f"Updated: {manifest.updated_at}",
+        "",
+        "Overall:",
+        f"  Shards: {len(shard_progress)}",
+        f"  Files: {total_files}",
+        f"  Exported: {total_exported}/{total_files}",
+        f"  Transformed: {total_transformed}/{total_files}",
+        f"  Imported: {total_imported}/{total_files}",
+        f"  Error files: {total_errors}",
+        "",
+        "Shard progress:",
+        "  Shard  Files  Exported  Transformed  Imported  State",
+    ]
+    lines.extend(
+        (
+            "  "
+            f"{progress.shard_id:<5}  "
+            f"{progress.file_count}/{progress.file_count:<3}  "
+            f"{progress.exported_count}/{progress.file_count:<3}       "
+            f"{progress.transformed_count}/{progress.file_count:<3}          "
+            f"{progress.imported_count}/{progress.file_count:<3}       "
+            f"{progress.state}"
+        )
+        for progress in shard_progress
+    )
+
+    if total_errors:
+        lines.extend(["", "Errors:"])
+        for progress in shard_progress:
+            if not progress.errors:
+                continue
+            lines.append(f"  Shard {progress.shard_id}")
+            for file_name, error in progress.errors:
+                lines.append(f"    File: {file_name}")
+                lines.append(f"    Error: {error}")
+
+    return "\n".join(lines) + "\n"
+
+
 def _export_files(
     run_dir: Path,
     manifest: MigrationManifest,
@@ -1032,6 +1240,9 @@ def _import_files(
             "No discovered files found in the manifest. Run transform first."
         )
 
+    manifest.status = "importing"
+    _save_manifest(run_dir, manifest)
+
     imported_count = 0
     for record in manifest.files:
         file_path = Path(record.export_lp_path)
@@ -1087,6 +1298,7 @@ def _import_files(
 
         record.imported_at = _utc_now()
         record.last_error = None
+        _save_manifest(run_dir, manifest)
         imported_count += 1
 
     manifest.status = "imported"
@@ -1405,6 +1617,19 @@ def import_command(
     click.echo(f"Imported {imported_count} file(s).")
 
 
+@click.command("status")
+@click.option(
+    "--run-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    required=True,
+    help="Migration run directory containing migration-manifest.json.",
+)
+def status_command(run_dir: Path) -> None:
+    """Report migration progress for a single run directory."""
+    manifest = _load_manifest_from_run_dir(run_dir)
+    click.echo(_render_status_report(manifest), nl=False)
+
+
 @click.group("migrate")
 def migrate() -> None:
     """Migration workflow commands for InfluxDB backups."""
@@ -1414,3 +1639,4 @@ migrate.add_command(discover)
 migrate.add_command(export_command)
 migrate.add_command(transform_command)
 migrate.add_command(import_command)
+migrate.add_command(status_command)

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -74,43 +74,9 @@ def _run_id(
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
 
 
-def _slugify(value: str) -> str:
-    """Create a filesystem-friendly slug."""
-    return "".join(
-        char if char.isalnum() or char in ".-_" else "_" for char in value
-    )
-
-
-def _run_dir_name(
-    backup_name: str,
-    database: str,
-    retention: str,
-    shards: list[str],
-) -> str:
-    """Return the per-run working directory name."""
-    run_id = _run_id(backup_name, database, retention, shards)
-    return f"{_slugify(database)}--{_slugify(retention)}--{run_id}"
-
-
 def _manifest_path(run_dir: Path) -> Path:
     """Return the manifest path within a run directory."""
     return run_dir / "migration-manifest.json"
-
-
-def _run_dir(
-    work_dir: Path,
-    backup_dir: Path,
-    database: str,
-    retention: str,
-    shards: list[str],
-) -> Path:
-    """Return the working directory for one migration run."""
-    return work_dir / _run_dir_name(
-        backup_dir.name,
-        database,
-        retention,
-        shards,
-    )
 
 
 @dataclass
@@ -215,86 +181,6 @@ def _load_manifest_from_run_dir(run_dir: Path) -> MigrationManifest:
         raise click.ClickException(
             f"Manifest file {manifest_path} is missing required fields."
         ) from exc
-
-
-def _load_manifest(
-    run_dir: Path,
-    backup_dir: Path,
-    database: str,
-    retention: str,
-    selection_shards: list[str],
-    *,
-    all_shards: bool,
-) -> MigrationManifest:
-    """Load an existing manifest or initialize a new one."""
-    run_dir.mkdir(parents=True, exist_ok=True)
-    manifest_path = _manifest_path(run_dir)
-    if manifest_path.exists():
-        data = json.loads(manifest_path.read_text(encoding="utf-8"))
-        manifest = MigrationManifest(
-            run_id=data["run_id"],
-            backup_dir=data["backup_dir"],
-            backup_name=data["backup_name"],
-            database=data["database"],
-            retention=data["retention"],
-            all_shards=data.get("all_shards", False),
-            shards=list(data["shards"]),
-            created_at=data["created_at"],
-            updated_at=data["updated_at"],
-            status=data["status"],
-            transform_plan_path=data.get("transform_plan_path"),
-            transform_plan_hash=data.get("transform_plan_hash"),
-            files=[
-                MigrationFileRecord(**record)
-                for record in data.get("files", [])
-            ],
-        )
-        expected = {
-            "backup_dir": str(backup_dir),
-            "backup_name": backup_dir.name,
-            "database": database,
-            "retention": retention,
-            "all_shards": all_shards,
-        }
-        actual = {
-            "backup_dir": manifest.backup_dir,
-            "backup_name": manifest.backup_name,
-            "database": manifest.database,
-            "retention": manifest.retention,
-            "all_shards": manifest.all_shards,
-        }
-        if actual != expected:
-            raise click.ClickException(
-                "Existing migration manifest does not match "
-                "the supplied inputs."
-            )
-        if not all_shards and sorted(manifest.shards) != sorted(
-            selection_shards
-        ):
-            raise click.ClickException(
-                "Existing migration manifest does not match "
-                "the supplied shard list."
-            )
-        return manifest
-
-    now = _utc_now()
-    return MigrationManifest(
-        run_id=_run_id(
-            backup_dir.name,
-            database,
-            retention,
-            selection_shards,
-        ),
-        backup_dir=str(backup_dir),
-        backup_name=backup_dir.name,
-        database=database,
-        retention=retention,
-        all_shards=all_shards,
-        shards=[] if all_shards else sorted(selection_shards),
-        created_at=now,
-        updated_at=now,
-        status="initialized",
-    )
 
 
 @dataclass(frozen=True)
@@ -1306,13 +1192,13 @@ def _import_files(
     return imported_count
 
 
-def _common_run_options[F: Callable[..., Any]](function: F) -> F:
-    """Add shared migration-run options to a Click command."""
+def _discover_options[F: Callable[..., Any]](function: F) -> F:
+    """Add discover-specific run and source options to a command."""
     function = click.option(
-        "--work-dir",
+        "--run-dir",
         type=click.Path(file_okay=False, path_type=Path),
         required=True,
-        help="Directory to store per-run manifests and migration artifacts.",
+        help="New migration run directory to create.",
     )(function)
     function = click.option("--retention", required=True)(function)
     function = click.option("--database", required=True)(function)
@@ -1363,15 +1249,25 @@ def _optional_shard_selection_options[F: Callable[..., Any]](
     )(function)
 
 
+def _run_dir_option[F: Callable[..., Any]](function: F) -> F:
+    """Add a required migration run directory option."""
+    return click.option(
+        "--run-dir",
+        type=click.Path(file_okay=False, path_type=Path),
+        required=True,
+        help="Migration run directory containing migration-manifest.json.",
+    )(function)
+
+
 @click.command("discover")
-@_common_run_options
+@_discover_options
 @_required_shard_selection_options
 def discover(
+    run_dir: Path,
     backup_dir: Path,
     database: str,
     retention: str,
     shards: tuple[str, ...],
-    work_dir: Path,
     *,
     all_shards: bool,
 ) -> None:
@@ -1382,20 +1278,26 @@ def discover(
         require_selection=True,
         default_all_shards=False,
     )
-    run_dir = _run_dir(
-        work_dir,
-        backup_dir,
-        database,
-        retention,
-        selection_shards,
-    )
-    manifest = _load_manifest(
-        run_dir,
-        backup_dir,
-        database,
-        retention,
-        selection_shards,
+    if run_dir.exists():
+        raise click.ClickException(f"Run directory {run_dir} already exists.")
+    run_dir.mkdir(parents=True, exist_ok=False)
+    now = _utc_now()
+    manifest = MigrationManifest(
+        run_id=_run_id(
+            backup_dir.name,
+            database,
+            retention,
+            selection_shards,
+        ),
+        backup_dir=str(backup_dir),
+        backup_name=backup_dir.name,
+        database=database,
+        retention=retention,
         all_shards=use_all_shards,
+        shards=[] if use_all_shards else sorted(selection_shards),
+        created_at=now,
+        updated_at=now,
+        status="initialized",
     )
     discovered_count = _discover_files(run_dir, manifest, backup_dir)
     click.echo(
@@ -1406,47 +1308,19 @@ def discover(
 
 
 @click.command("export")
-@_common_run_options
-@_required_shard_selection_options
+@_run_dir_option
 @click.option(
     "--force",
     is_flag=True,
     help="Re-export files already marked exported in the manifest.",
 )
 def export_command(
-    backup_dir: Path,
-    database: str,
-    retention: str,
-    shards: tuple[str, ...],
-    work_dir: Path,
+    run_dir: Path,
     *,
-    all_shards: bool,
     force: bool,
 ) -> None:
     """Export discovered TSM files to line protocol."""
-    selection_shards, use_all_shards = _resolve_shard_selection(
-        shards,
-        all_shards=all_shards,
-        require_selection=True,
-        default_all_shards=False,
-    )
-    run_dir = _run_dir(
-        work_dir,
-        backup_dir,
-        database,
-        retention,
-        selection_shards,
-    )
-    manifest = _load_manifest(
-        run_dir,
-        backup_dir,
-        database,
-        retention,
-        selection_shards,
-        all_shards=use_all_shards,
-    )
-    if not manifest.files:
-        _discover_files(run_dir, manifest, backup_dir)
+    manifest = _load_manifest_from_run_dir(run_dir)
     exported_count = _export_files(
         run_dir,
         manifest,
@@ -1456,8 +1330,7 @@ def export_command(
 
 
 @click.command("transform")
-@_common_run_options
-@_optional_shard_selection_options
+@_run_dir_option
 @click.option(
     "--plan",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
@@ -1470,38 +1343,13 @@ def export_command(
     help="Reapply the transform plan to files already marked transformed.",
 )
 def transform_command(
-    backup_dir: Path,
-    database: str,
-    retention: str,
-    shards: tuple[str, ...],
-    work_dir: Path,
+    run_dir: Path,
     plan: Path,
     *,
-    all_shards: bool,
     force: bool,
 ) -> None:
     """Transform exported line protocol files in place."""
-    selection_shards, use_all_shards = _resolve_shard_selection(
-        shards,
-        all_shards=all_shards,
-        require_selection=False,
-        default_all_shards=True,
-    )
-    run_dir = _run_dir(
-        work_dir,
-        backup_dir,
-        database,
-        retention,
-        selection_shards,
-    )
-    manifest = _load_manifest(
-        run_dir,
-        backup_dir,
-        database,
-        retention,
-        selection_shards,
-        all_shards=use_all_shards,
-    )
+    manifest = _load_manifest_from_run_dir(run_dir)
     transformed_count = _transform_files(
         run_dir,
         manifest,
@@ -1512,8 +1360,7 @@ def transform_command(
 
 
 @click.command("import")
-@_common_run_options
-@_optional_shard_selection_options
+@_run_dir_option
 @click.option("--host", required=True, help="InfluxDB host name.")
 @click.option("--port", type=int, default=8086, show_default=True)
 @click.option("--username", default=None, help="InfluxDB username.")
@@ -1554,11 +1401,7 @@ def transform_command(
     help="Re-import files already marked imported in the manifest.",
 )
 def import_command(
-    backup_dir: Path,
-    database: str,
-    retention: str,
-    shards: tuple[str, ...],
-    work_dir: Path,
+    run_dir: Path,
     host: str,
     port: int,
     username: str | None,
@@ -1568,34 +1411,13 @@ def import_command(
     precision: str,
     pps: int,
     *,
-    all_shards: bool,
     compressed: bool,
     ssl: bool,
     unsafe_ssl: bool,
     force: bool,
 ) -> None:
     """Import transformed line protocol files into InfluxDB."""
-    selection_shards, use_all_shards = _resolve_shard_selection(
-        shards,
-        all_shards=all_shards,
-        require_selection=False,
-        default_all_shards=True,
-    )
-    run_dir = _run_dir(
-        work_dir,
-        backup_dir,
-        database,
-        retention,
-        selection_shards,
-    )
-    manifest = _load_manifest(
-        run_dir,
-        backup_dir,
-        database,
-        retention,
-        selection_shards,
-        all_shards=use_all_shards,
-    )
+    manifest = _load_manifest_from_run_dir(run_dir)
     resolved_target_database = target_database or manifest.database
     resolved_target_retention = target_retention or manifest.retention
     imported_count = _import_files(
@@ -1618,12 +1440,7 @@ def import_command(
 
 
 @click.command("status")
-@click.option(
-    "--run-dir",
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-    required=True,
-    help="Migration run directory containing migration-manifest.json.",
-)
+@_run_dir_option
 def status_command(run_dir: Path) -> None:
     """Report migration progress for a single run directory."""
     manifest = _load_manifest_from_run_dir(run_dir)

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -183,6 +183,16 @@ def _load_manifest_from_run_dir(run_dir: Path) -> MigrationManifest:
         ) from exc
 
 
+def _run_phase(name: str, operation: Callable[[], None]) -> None:
+    """Run one migration phase with stdout progress and error output."""
+    click.echo(f"Running {name}...")
+    try:
+        operation()
+    except click.ClickException as exc:
+        click.echo(f"Error: {exc.message}")
+        raise
+
+
 @dataclass(frozen=True)
 class BackupManifestShard:
     """One shard entry from a backup manifest."""
@@ -1382,51 +1392,57 @@ def discover(
     all_shards: bool,
 ) -> None:
     """Discover TSM files for a migration run."""
-    selection_shards, use_all_shards = _resolve_shard_selection(
-        shards,
-        all_shards=all_shards,
-        require_selection=True,
-        default_all_shards=False,
-    )
-    resolved_shards, discovered_entries = _discover_entries(
-        backup_dir=backup_dir,
-        database=database,
-        retention=retention,
-        all_shards=use_all_shards,
-        shards=selection_shards,
-    )
-    if run_dir.exists():
-        raise click.ClickException(f"Run directory {run_dir} already exists.")
-    run_dir.mkdir(parents=True, exist_ok=False)
-    now = _utc_now()
-    manifest = MigrationManifest(
-        run_id=_run_id(
-            backup_dir.name,
-            database,
-            retention,
-            selection_shards,
-        ),
-        backup_dir=str(backup_dir),
-        backup_name=backup_dir.name,
-        database=database,
-        retention=retention,
-        all_shards=use_all_shards,
-        shards=[] if use_all_shards else resolved_shards,
-        created_at=now,
-        updated_at=now,
-        status="initialized",
-    )
-    discovered_count = _discover_files(
-        run_dir,
-        manifest,
-        discovered_entries,
-        resolved_shards,
-    )
-    click.echo(
-        "Discovered "
-        f"{discovered_count} TSM file(s) in "
-        f"{len(manifest.shards)} shard(s)."
-    )
+
+    def _operation() -> None:
+        selection_shards, use_all_shards = _resolve_shard_selection(
+            shards,
+            all_shards=all_shards,
+            require_selection=True,
+            default_all_shards=False,
+        )
+        resolved_shards, discovered_entries = _discover_entries(
+            backup_dir=backup_dir,
+            database=database,
+            retention=retention,
+            all_shards=use_all_shards,
+            shards=selection_shards,
+        )
+        if run_dir.exists():
+            raise click.ClickException(
+                f"Run directory {run_dir} already exists."
+            )
+        run_dir.mkdir(parents=True, exist_ok=False)
+        now = _utc_now()
+        manifest = MigrationManifest(
+            run_id=_run_id(
+                backup_dir.name,
+                database,
+                retention,
+                selection_shards,
+            ),
+            backup_dir=str(backup_dir),
+            backup_name=backup_dir.name,
+            database=database,
+            retention=retention,
+            all_shards=use_all_shards,
+            shards=[] if use_all_shards else resolved_shards,
+            created_at=now,
+            updated_at=now,
+            status="initialized",
+        )
+        discovered_count = _discover_files(
+            run_dir,
+            manifest,
+            discovered_entries,
+            resolved_shards,
+        )
+        click.echo(
+            "Discovered "
+            f"{discovered_count} TSM file(s) in "
+            f"{len(manifest.shards)} shard(s)."
+        )
+
+    _run_phase("discover", _operation)
 
 
 @click.command("export")
@@ -1442,13 +1458,17 @@ def export_command(
     force: bool,
 ) -> None:
     """Export discovered TSM files to line protocol."""
-    manifest = _load_manifest_from_run_dir(run_dir)
-    exported_count = _export_files(
-        run_dir,
-        manifest,
-        force=force,
-    )
-    click.echo(f"Exported {exported_count} file(s).")
+
+    def _operation() -> None:
+        manifest = _load_manifest_from_run_dir(run_dir)
+        exported_count = _export_files(
+            run_dir,
+            manifest,
+            force=force,
+        )
+        click.echo(f"Exported {exported_count} file(s).")
+
+    _run_phase("export", _operation)
 
 
 @click.command("transform")
@@ -1471,14 +1491,18 @@ def transform_command(
     force: bool,
 ) -> None:
     """Transform exported line protocol files in place."""
-    manifest = _load_manifest_from_run_dir(run_dir)
-    transformed_count = _transform_files(
-        run_dir,
-        manifest,
-        plan,
-        force=force,
-    )
-    click.echo(f"Transformed {transformed_count} file(s).")
+
+    def _operation() -> None:
+        manifest = _load_manifest_from_run_dir(run_dir)
+        transformed_count = _transform_files(
+            run_dir,
+            manifest,
+            plan,
+            force=force,
+        )
+        click.echo(f"Transformed {transformed_count} file(s).")
+
+    _run_phase("transform", _operation)
 
 
 @click.command("import")
@@ -1539,26 +1563,30 @@ def import_command(
     force: bool,
 ) -> None:
     """Import transformed line protocol files into InfluxDB."""
-    manifest = _load_manifest_from_run_dir(run_dir)
-    resolved_target_database = target_database or manifest.database
-    resolved_target_retention = target_retention or manifest.retention
-    imported_count = _import_files(
-        run_dir,
-        manifest,
-        target_database=resolved_target_database,
-        target_retention=resolved_target_retention,
-        host=host,
-        port=port,
-        username=username,
-        password=password,
-        precision=precision,
-        pps=pps,
-        compressed=compressed,
-        ssl=ssl,
-        unsafe_ssl=unsafe_ssl,
-        force=force,
-    )
-    click.echo(f"Imported {imported_count} file(s).")
+
+    def _operation() -> None:
+        manifest = _load_manifest_from_run_dir(run_dir)
+        resolved_target_database = target_database or manifest.database
+        resolved_target_retention = target_retention or manifest.retention
+        imported_count = _import_files(
+            run_dir,
+            manifest,
+            target_database=resolved_target_database,
+            target_retention=resolved_target_retention,
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            precision=precision,
+            pps=pps,
+            compressed=compressed,
+            ssl=ssl,
+            unsafe_ssl=unsafe_ssl,
+            force=force,
+        )
+        click.echo(f"Imported {imported_count} file(s).")
+
+    _run_phase("import", _operation)
 
 
 @click.command("status")

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -20,6 +20,8 @@ from .measurements import drop_measurement, rename_measurement
 from .tag_to_field import TagToFieldConflictError, convert_tag_to_field
 from .tags import drop_measurement_tag_key, rename_measurement_tag_key
 
+ALL_SHARDS_SENTINEL = "__all_shards__"
+
 
 def _utc_now() -> str:
     """Return the current UTC timestamp in ISO 8601 format."""
@@ -28,10 +30,29 @@ def _utc_now() -> str:
 
 def _stringify_shards(shards: tuple[str, ...]) -> list[str]:
     """Normalize shard identifiers into non-empty strings."""
-    normalized = [str(shard).strip() for shard in shards if str(shard).strip()]
-    if not normalized:
-        raise click.UsageError("Provide at least one --shard value.")
-    return normalized
+    return [str(shard).strip() for shard in shards if str(shard).strip()]
+
+
+def _resolve_shard_selection(
+    shards: tuple[str, ...],
+    *,
+    all_shards: bool,
+    require_selection: bool,
+    default_all_shards: bool,
+) -> tuple[list[str], bool]:
+    """Resolve shard selection for a migration command."""
+    normalized_shards = _stringify_shards(shards)
+    if all_shards and normalized_shards:
+        raise click.UsageError("Use either --shard or --all-shards, not both.")
+    if all_shards or (default_all_shards and not normalized_shards):
+        return [ALL_SHARDS_SENTINEL], True
+    if normalized_shards:
+        return normalized_shards, False
+    if require_selection:
+        raise click.UsageError(
+            "Provide at least one --shard value or use --all-shards."
+        )
+    raise click.UsageError("Could not determine shard selection.")
 
 
 def _run_id(
@@ -119,6 +140,7 @@ class MigrationManifest:
     backup_name: str
     database: str
     retention: str
+    all_shards: bool
     shards: list[str]
     created_at: str
     updated_at: str
@@ -146,7 +168,9 @@ def _load_manifest(
     backup_dir: Path,
     database: str,
     retention: str,
-    shards: list[str],
+    selection_shards: list[str],
+    *,
+    all_shards: bool,
 ) -> MigrationManifest:
     """Load an existing manifest or initialize a new one."""
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -159,6 +183,7 @@ def _load_manifest(
             backup_name=data["backup_name"],
             database=data["database"],
             retention=data["retention"],
+            all_shards=data.get("all_shards", False),
             shards=list(data["shards"]),
             created_at=data["created_at"],
             updated_at=data["updated_at"],
@@ -175,33 +200,109 @@ def _load_manifest(
             "backup_name": backup_dir.name,
             "database": database,
             "retention": retention,
-            "shards": sorted(shards),
+            "all_shards": all_shards,
         }
         actual = {
             "backup_dir": manifest.backup_dir,
             "backup_name": manifest.backup_name,
             "database": manifest.database,
             "retention": manifest.retention,
-            "shards": sorted(manifest.shards),
+            "all_shards": manifest.all_shards,
         }
         if actual != expected:
             raise click.ClickException(
                 "Existing migration manifest does not match "
                 "the supplied inputs."
             )
+        if not all_shards and sorted(manifest.shards) != sorted(
+            selection_shards
+        ):
+            raise click.ClickException(
+                "Existing migration manifest does not match "
+                "the supplied shard list."
+            )
         return manifest
 
     now = _utc_now()
     return MigrationManifest(
-        run_id=_run_id(backup_dir.name, database, retention, shards),
+        run_id=_run_id(
+            backup_dir.name,
+            database,
+            retention,
+            selection_shards,
+        ),
         backup_dir=str(backup_dir),
         backup_name=backup_dir.name,
         database=database,
         retention=retention,
-        shards=sorted(shards),
+        all_shards=all_shards,
+        shards=[] if all_shards else sorted(selection_shards),
         created_at=now,
         updated_at=now,
         status="initialized",
+    )
+
+
+@dataclass(frozen=True)
+class BackupManifestShard:
+    """One shard entry from a backup manifest."""
+
+    shard_id: str
+    archive_path: Path
+
+
+def _load_backup_manifest(backup_dir: Path) -> list[dict[str, Any]]:
+    """Load the single backup manifest from a backup directory."""
+    manifest_paths = sorted(backup_dir.glob("*.manifest"))
+    if not manifest_paths:
+        raise click.ClickException(
+            f"No backup manifest file found in {backup_dir}."
+        )
+    if len(manifest_paths) > 1:
+        raise click.ClickException(
+            f"Multiple backup manifest files found in {backup_dir}."
+        )
+    data = json.loads(manifest_paths[0].read_text(encoding="utf-8"))
+    files = data.get("files")
+    if not isinstance(files, list):
+        raise click.ClickException(
+            "Backup manifest "
+            f"{manifest_paths[0]} is missing a valid files list."
+        )
+    return [entry for entry in files if isinstance(entry, dict)]
+
+
+def _select_manifest_shards(
+    backup_dir: Path,
+    *,
+    database: str,
+    retention: str,
+) -> list[BackupManifestShard]:
+    """Select candidate shards from the backup manifest."""
+    selected: list[BackupManifestShard] = []
+    for entry in _load_backup_manifest(backup_dir):
+        if entry.get("database") != database:
+            continue
+        if entry.get("policy") != retention:
+            continue
+        shard_id = entry.get("shardID")
+        file_name = entry.get("fileName")
+        if shard_id is None or not isinstance(file_name, str):
+            continue
+        selected.append(
+            BackupManifestShard(
+                shard_id=str(shard_id),
+                archive_path=backup_dir / file_name,
+            )
+        )
+    if not selected:
+        raise click.ClickException(
+            "No shard entries found in the backup manifest for the "
+            "requested database and retention."
+        )
+    return sorted(
+        selected,
+        key=lambda shard: (shard.shard_id, shard.archive_path),
     )
 
 
@@ -221,6 +322,10 @@ def _discover_shard_files(
     expected_prefix = f"{database}/{retention}/{shard_id}/"
 
     for archive_path in _iter_shard_archives(backup_dir, shard_id):
+        if not archive_path.exists():
+            raise click.ClickException(
+                f"Backup shard archive {archive_path} is missing."
+            )
         with tarfile.open(archive_path, "r:gz") as archive:
             for member in archive.getmembers():
                 if not member.isfile():
@@ -234,6 +339,48 @@ def _discover_shard_files(
     return discovered
 
 
+def _discover_manifest_shard_files(
+    manifest_shards: list[BackupManifestShard],
+    *,
+    database: str,
+    retention: str,
+) -> list[tuple[str, Path, str]]:
+    """Discover TSM files for manifest-selected shards."""
+    discovered: list[tuple[str, Path, str]] = []
+    for manifest_shard in manifest_shards:
+        archive_path = manifest_shard.archive_path
+        if not archive_path.exists():
+            raise click.ClickException(
+                f"Backup shard archive {archive_path} is missing."
+            )
+        expected_prefix = f"{database}/{retention}/{manifest_shard.shard_id}/"
+        matching_members: list[str] = []
+        with tarfile.open(archive_path, "r:gz") as archive:
+            for member in archive.getmembers():
+                if not member.isfile():
+                    continue
+                if not member.name.endswith(".tsm"):
+                    continue
+                if not member.name.startswith(expected_prefix):
+                    continue
+                matching_members.append(member.name)
+        if not matching_members:
+            raise click.ClickException(
+                "Backup shard archive "
+                f"{archive_path} does not contain matching TSM files "
+                f"for {database}/{retention}/{manifest_shard.shard_id}."
+            )
+        discovered.extend(
+            (
+                manifest_shard.shard_id,
+                archive_path,
+                member_name,
+            )
+            for member_name in matching_members
+        )
+    return discovered
+
+
 def _discover_files(
     run_dir: Path,
     manifest: MigrationManifest,
@@ -241,20 +388,23 @@ def _discover_files(
 ) -> int:
     """Populate the manifest with discovered shard files."""
     files: list[MigrationFileRecord] = []
-    for shard_id in manifest.shards:
-        discovered = _discover_shard_files(
-            backup_dir,
-            manifest.database,
-            manifest.retention,
-            shard_id,
+    if manifest.all_shards:
+        discovered_entries = _discover_manifest_shard_files(
+            _select_manifest_shards(
+                backup_dir,
+                database=manifest.database,
+                retention=manifest.retention,
+            ),
+            database=manifest.database,
+            retention=manifest.retention,
         )
-        if not discovered:
-            raise click.ClickException(
-                "No TSM files found for shard "
-                f"{shard_id!r} in the backup directory."
-            )
-
-        for archive_path, member_name in discovered:
+        manifest.shards = sorted(
+            {
+                shard_id
+                for shard_id, _archive_path, _member_name in discovered_entries
+            }
+        )
+        for shard_id, archive_path, member_name in discovered_entries:
             tsm_stem = Path(member_name).stem
             files.append(
                 MigrationFileRecord(
@@ -265,6 +415,33 @@ def _discover_files(
                     discovered_at=_utc_now(),
                 )
             )
+    else:
+        for shard_id in manifest.shards:
+            discovered = _discover_shard_files(
+                backup_dir,
+                manifest.database,
+                manifest.retention,
+                shard_id,
+            )
+            if not discovered:
+                raise click.ClickException(
+                    "No TSM files found for shard "
+                    f"{shard_id!r} in the backup directory."
+                )
+
+            for archive_path, member_name in discovered:
+                tsm_stem = Path(member_name).stem
+                files.append(
+                    MigrationFileRecord(
+                        shard_id=shard_id,
+                        archive_path=str(archive_path),
+                        archive_member_path=member_name,
+                        export_lp_path=str(
+                            run_dir / shard_id / f"{tsm_stem}.lp"
+                        ),
+                        discovered_at=_utc_now(),
+                    )
+                )
 
     manifest.files = sorted(
         files,
@@ -925,13 +1102,6 @@ def _common_run_options[F: Callable[..., Any]](function: F) -> F:
         required=True,
         help="Directory to store per-run manifests and migration artifacts.",
     )(function)
-    function = click.option(
-        "--shard",
-        "shards",
-        multiple=True,
-        required=True,
-        help="Shard ID to include. Repeat for multiple shards.",
-    )(function)
     function = click.option("--retention", required=True)(function)
     function = click.option("--database", required=True)(function)
     return click.option(
@@ -941,30 +1111,79 @@ def _common_run_options[F: Callable[..., Any]](function: F) -> F:
     )(function)
 
 
+def _required_shard_selection_options[F: Callable[..., Any]](
+    function: F,
+) -> F:
+    """Add required shard-selection options."""
+    function = click.option(
+        "--all-shards",
+        is_flag=True,
+        help=(
+            "Use all shards from the backup manifest that match "
+            "the database and retention."
+        ),
+    )(function)
+    return click.option(
+        "--shard",
+        "shards",
+        multiple=True,
+        help="Shard ID to include. Repeat for multiple shards.",
+    )(function)
+
+
+def _optional_shard_selection_options[F: Callable[..., Any]](
+    function: F,
+) -> F:
+    """Add optional shard-selection options."""
+    function = click.option(
+        "--all-shards",
+        is_flag=True,
+        help=(
+            "Use all shards from the all-shards migration run. "
+            "This is the default when no shard selection is given."
+        ),
+    )(function)
+    return click.option(
+        "--shard",
+        "shards",
+        multiple=True,
+        help="Shard ID to include. Repeat for multiple shards.",
+    )(function)
+
+
 @click.command("discover")
 @_common_run_options
+@_required_shard_selection_options
 def discover(
     backup_dir: Path,
     database: str,
     retention: str,
     shards: tuple[str, ...],
     work_dir: Path,
+    *,
+    all_shards: bool,
 ) -> None:
     """Discover TSM files for a migration run."""
-    normalized_shards = _stringify_shards(shards)
+    selection_shards, use_all_shards = _resolve_shard_selection(
+        shards,
+        all_shards=all_shards,
+        require_selection=True,
+        default_all_shards=False,
+    )
     run_dir = _run_dir(
         work_dir,
         backup_dir,
         database,
         retention,
-        normalized_shards,
+        selection_shards,
     )
     manifest = _load_manifest(
         run_dir,
         backup_dir,
         database,
         retention,
-        normalized_shards,
+        selection_shards,
+        all_shards=use_all_shards,
     )
     discovered_count = _discover_files(run_dir, manifest, backup_dir)
     click.echo(
@@ -976,6 +1195,7 @@ def discover(
 
 @click.command("export")
 @_common_run_options
+@_required_shard_selection_options
 @click.option(
     "--force",
     is_flag=True,
@@ -988,23 +1208,30 @@ def export_command(
     shards: tuple[str, ...],
     work_dir: Path,
     *,
+    all_shards: bool,
     force: bool,
 ) -> None:
     """Export discovered TSM files to line protocol."""
-    normalized_shards = _stringify_shards(shards)
+    selection_shards, use_all_shards = _resolve_shard_selection(
+        shards,
+        all_shards=all_shards,
+        require_selection=True,
+        default_all_shards=False,
+    )
     run_dir = _run_dir(
         work_dir,
         backup_dir,
         database,
         retention,
-        normalized_shards,
+        selection_shards,
     )
     manifest = _load_manifest(
         run_dir,
         backup_dir,
         database,
         retention,
-        normalized_shards,
+        selection_shards,
+        all_shards=use_all_shards,
     )
     if not manifest.files:
         _discover_files(run_dir, manifest, backup_dir)
@@ -1018,6 +1245,7 @@ def export_command(
 
 @click.command("transform")
 @_common_run_options
+@_optional_shard_selection_options
 @click.option(
     "--plan",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
@@ -1037,23 +1265,30 @@ def transform_command(
     work_dir: Path,
     plan: Path,
     *,
+    all_shards: bool,
     force: bool,
 ) -> None:
     """Transform exported line protocol files in place."""
-    normalized_shards = _stringify_shards(shards)
+    selection_shards, use_all_shards = _resolve_shard_selection(
+        shards,
+        all_shards=all_shards,
+        require_selection=False,
+        default_all_shards=True,
+    )
     run_dir = _run_dir(
         work_dir,
         backup_dir,
         database,
         retention,
-        normalized_shards,
+        selection_shards,
     )
     manifest = _load_manifest(
         run_dir,
         backup_dir,
         database,
         retention,
-        normalized_shards,
+        selection_shards,
+        all_shards=use_all_shards,
     )
     transformed_count = _transform_files(
         run_dir,
@@ -1066,6 +1301,7 @@ def transform_command(
 
 @click.command("import")
 @_common_run_options
+@_optional_shard_selection_options
 @click.option("--host", required=True, help="InfluxDB host name.")
 @click.option("--port", type=int, default=8086, show_default=True)
 @click.option("--username", default=None, help="InfluxDB username.")
@@ -1120,26 +1356,33 @@ def import_command(
     precision: str,
     pps: int,
     *,
+    all_shards: bool,
     compressed: bool,
     ssl: bool,
     unsafe_ssl: bool,
     force: bool,
 ) -> None:
     """Import transformed line protocol files into InfluxDB."""
-    normalized_shards = _stringify_shards(shards)
+    selection_shards, use_all_shards = _resolve_shard_selection(
+        shards,
+        all_shards=all_shards,
+        require_selection=False,
+        default_all_shards=True,
+    )
     run_dir = _run_dir(
         work_dir,
         backup_dir,
         database,
         retention,
-        normalized_shards,
+        selection_shards,
     )
     manifest = _load_manifest(
         run_dir,
         backup_dir,
         database,
         retention,
-        normalized_shards,
+        selection_shards,
+        all_shards=use_all_shards,
     )
     resolved_target_database = target_database or manifest.database
     resolved_target_retention = target_retention or manifest.retention

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -16,6 +16,11 @@ import click
 import yaml
 
 from .fields import drop_measurement_field_key, rename_measurement_field_key
+from .line_protocol import (
+    _extract_measurement_from_series_key,
+    _is_metadata_line,
+    _split_record_content,
+)
 from .measurements import drop_measurement, rename_measurement
 from .tag_to_field import TagToFieldConflictError, convert_tag_to_field
 from .tags import drop_measurement_tag_key, rename_measurement_tag_key
@@ -190,7 +195,7 @@ def _run_phase(name: str, operation: Callable[[], None]) -> None:
         operation()
     except click.ClickException as exc:
         click.echo(f"Error: {exc.message}")
-        raise
+        raise click.exceptions.Exit(1) from exc
 
 
 @dataclass(frozen=True)
@@ -1131,11 +1136,51 @@ def _render_status_report(manifest: MigrationManifest) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _has_unterminated_quoted_field(text: str) -> bool:
+    """Return whether a field-set fragment ends inside a quoted string."""
+    escaped = False
+    in_quotes = False
+    for char in text:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == '"':
+            in_quotes = not in_quotes
+    return in_quotes
+
+
+def _verify_exported_lp_file(file_path: Path) -> None:
+    """Reject exported LP files that contain multiline records."""
+    for line_number, raw_line in enumerate(
+        file_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if _is_metadata_line(raw_line):
+            continue
+        record_parts = _split_record_content(raw_line)
+        if record_parts is None:
+            continue
+        series_key, field_set, remainder = record_parts
+        if not _has_unterminated_quoted_field(field_set + remainder):
+            continue
+        measurement = _extract_measurement_from_series_key(series_key)
+        raise click.ClickException(
+            "Exported file "
+            f"{file_path} contains a multiline line protocol record for "
+            f"measurement {measurement!r} starting at line {line_number}. "
+            "This export cannot be imported safely."
+        )
+
+
 def _export_files(
     run_dir: Path,
     manifest: MigrationManifest,
     *,
     force: bool,
+    verify: bool,
 ) -> int:
     """Export discovered TSM files to line protocol."""
     if not manifest.files:
@@ -1206,6 +1251,14 @@ def _export_files(
             )
             _save_manifest(run_dir, manifest)
             raise click.ClickException(record.last_error)
+
+        if verify:
+            try:
+                _verify_exported_lp_file(export_lp_path)
+            except click.ClickException as exc:
+                record.last_error = str(exc)
+                _save_manifest(run_dir, manifest)
+                raise
 
         record.exported_at = _utc_now()
         record.last_error = None
@@ -1452,10 +1505,16 @@ def discover(
     is_flag=True,
     help="Re-export files already marked exported in the manifest.",
 )
+@click.option(
+    "--verify",
+    is_flag=True,
+    help="Verify exported LP files do not contain multiline records.",
+)
 def export_command(
     run_dir: Path,
     *,
     force: bool,
+    verify: bool,
 ) -> None:
     """Export discovered TSM files to line protocol."""
 
@@ -1465,6 +1524,7 @@ def export_command(
             run_dir,
             manifest,
             force=force,
+            verify=verify,
         )
         click.echo(f"Exported {exported_count} file(s).")
 

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -814,6 +814,64 @@ def _rewrite_import_context(
     return None
 
 
+def _read_context_database(file_path: Path) -> str:
+    """Read the effective CONTEXT-DATABASE value from a line protocol file."""
+    for line in file_path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("# CONTEXT-DATABASE:"):
+            continue
+        database = line.split(":", 1)[1].strip()
+        if database:
+            return database
+        break
+    raise click.ClickException(
+        f"Line protocol file {file_path} is missing a CONTEXT-DATABASE header."
+    )
+
+
+def _extend_influx_connection_argv(
+    argv: list[str],
+    *,
+    host: str,
+    port: int,
+    username: str | None,
+    password: str | None,
+    ssl: bool,
+    unsafe_ssl: bool,
+) -> list[str]:
+    """Append shared InfluxDB CLI connection options."""
+    argv.extend(["-host", host, "-port", str(port)])
+    if username is not None:
+        argv.extend(["-username", username])
+    if password is not None:
+        argv.extend(["-password", password])
+    if ssl:
+        argv.append("-ssl")
+    if unsafe_ssl:
+        argv.append("-unsafeSsl")
+    return argv
+
+
+def _build_show_databases_argv(
+    *,
+    host: str,
+    port: int,
+    username: str | None,
+    password: str | None,
+    ssl: bool,
+    unsafe_ssl: bool,
+) -> list[str]:
+    """Build the influx CLI argv for SHOW DATABASES."""
+    return _extend_influx_connection_argv(
+        ["influx", "-execute", "SHOW DATABASES"],
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        ssl=ssl,
+        unsafe_ssl=unsafe_ssl,
+    )
+
+
 def _build_import_argv(
     *,
     file_path: Path,
@@ -828,31 +886,63 @@ def _build_import_argv(
     unsafe_ssl: bool,
 ) -> list[str]:
     """Build the influx CLI argv for one file import."""
-    argv = [
-        "influx",
-        "-host",
-        host,
-        "-port",
-        str(port),
-        "-import",
-        "-path",
-        str(file_path),
-        "-precision",
-        precision,
-    ]
-    if username is not None:
-        argv.extend(["-username", username])
-    if password is not None:
-        argv.extend(["-password", password])
+    argv = _extend_influx_connection_argv(
+        [
+            "influx",
+            "-import",
+            "-path",
+            str(file_path),
+            "-precision",
+            precision,
+        ],
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        ssl=ssl,
+        unsafe_ssl=unsafe_ssl,
+    )
     if pps:
         argv.extend(["-pps", str(pps)])
     if compressed:
         argv.append("-compressed")
-    if ssl:
-        argv.append("-ssl")
-    if unsafe_ssl:
-        argv.append("-unsafeSsl")
     return argv
+
+
+def _database_exists(
+    database: str,
+    *,
+    host: str,
+    port: int,
+    username: str | None,
+    password: str | None,
+    ssl: bool,
+    unsafe_ssl: bool,
+) -> bool:
+    """Return whether one database exists in the target InfluxDB instance."""
+    argv = _build_show_databases_argv(
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        ssl=ssl,
+        unsafe_ssl=unsafe_ssl,
+    )
+    result = _run_external_command(argv)
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        failure_message = message or "SHOW DATABASES failed."
+        raise click.ClickException(
+            f"Failed to list databases in InfluxDB: {failure_message}"
+        )
+
+    database_lines = {
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip() and not line.startswith("name:")
+    }
+    database_lines.discard("name")
+    return database in database_lines
 
 
 def _emit_import_context_message(
@@ -1143,6 +1233,7 @@ def _import_files(
     _save_manifest(run_dir, manifest)
 
     imported_count = 0
+    database_exists_cache: dict[str, bool] = {}
     for record in manifest.files:
         file_path = Path(record.export_lp_path)
         if not file_path.exists():
@@ -1168,6 +1259,32 @@ def _import_files(
             database=target_database,
             retention=target_retention,
         )
+        context_database = _read_context_database(file_path)
+        try:
+            database_exists = database_exists_cache.get(context_database)
+            if database_exists is None:
+                database_exists = _database_exists(
+                    context_database,
+                    host=host,
+                    port=port,
+                    username=username,
+                    password=password,
+                    ssl=ssl,
+                    unsafe_ssl=unsafe_ssl,
+                )
+                database_exists_cache[context_database] = database_exists
+        except click.ClickException as exc:
+            record.last_error = str(exc)
+            _save_manifest(run_dir, manifest)
+            raise
+        if not database_exists:
+            record.last_error = (
+                f'Database "{context_database}" does not exist in InfluxDB. '
+                "Create it before running import."
+            )
+            _save_manifest(run_dir, manifest)
+            raise click.ClickException(record.last_error)
+
         argv = _build_import_argv(
             file_path=file_path,
             host=host,

--- a/src/sasquatch/migration.py
+++ b/src/sasquatch/migration.py
@@ -321,69 +321,71 @@ def _discover_manifest_shard_files(
     return discovered
 
 
-def _discover_files(
-    run_dir: Path,
-    manifest: MigrationManifest,
+def _discover_entries(
+    *,
     backup_dir: Path,
-) -> int:
-    """Populate the manifest with discovered shard files."""
-    files: list[MigrationFileRecord] = []
-    if manifest.all_shards:
-        discovered_entries = _discover_manifest_shard_files(
+    database: str,
+    retention: str,
+    all_shards: bool,
+    shards: list[str],
+) -> tuple[list[str], list[tuple[str, Path, str]]]:
+    """Validate and collect discovered shard archive members."""
+    if all_shards:
+        manifest_entries = _discover_manifest_shard_files(
             _select_manifest_shards(
                 backup_dir,
-                database=manifest.database,
-                retention=manifest.retention,
+                database=database,
+                retention=retention,
             ),
-            database=manifest.database,
-            retention=manifest.retention,
+            database=database,
+            retention=retention,
         )
-        manifest.shards = sorted(
+        resolved_shards = sorted(
             {
                 shard_id
-                for shard_id, _archive_path, _member_name in discovered_entries
+                for shard_id, _archive_path, _member_name in manifest_entries
             }
         )
-        for shard_id, archive_path, member_name in discovered_entries:
-            tsm_stem = Path(member_name).stem
-            files.append(
-                MigrationFileRecord(
-                    shard_id=shard_id,
-                    archive_path=str(archive_path),
-                    archive_member_path=member_name,
-                    export_lp_path=str(run_dir / shard_id / f"{tsm_stem}.lp"),
-                    discovered_at=_utc_now(),
-                )
-            )
-    else:
-        for shard_id in manifest.shards:
-            discovered = _discover_shard_files(
-                backup_dir,
-                manifest.database,
-                manifest.retention,
-                shard_id,
-            )
-            if not discovered:
-                raise click.ClickException(
-                    "No TSM files found for shard "
-                    f"{shard_id!r} in the backup directory."
-                )
+        return resolved_shards, manifest_entries
 
-            for archive_path, member_name in discovered:
-                tsm_stem = Path(member_name).stem
-                files.append(
-                    MigrationFileRecord(
-                        shard_id=shard_id,
-                        archive_path=str(archive_path),
-                        archive_member_path=member_name,
-                        export_lp_path=str(
-                            run_dir / shard_id / f"{tsm_stem}.lp"
-                        ),
-                        discovered_at=_utc_now(),
-                    )
-                )
+    discovered_entries: list[tuple[str, Path, str]] = []
+    for shard_id in shards:
+        discovered = _discover_shard_files(
+            backup_dir,
+            database,
+            retention,
+            shard_id,
+        )
+        if not discovered:
+            raise click.ClickException(
+                "No TSM files found for shard "
+                f"{shard_id!r} in the backup directory."
+            )
+        discovered_entries.extend(
+            (shard_id, archive_path, member_name)
+            for archive_path, member_name in discovered
+        )
+    return sorted(shards), discovered_entries
 
-    manifest.files = sorted(
+
+def _build_discovered_records(
+    run_dir: Path,
+    discovered_entries: list[tuple[str, Path, str]],
+) -> list[MigrationFileRecord]:
+    """Build manifest file records from discovered archive members."""
+    files = []
+    for shard_id, archive_path, member_name in discovered_entries:
+        tsm_stem = Path(member_name).stem
+        files.append(
+            MigrationFileRecord(
+                shard_id=shard_id,
+                archive_path=str(archive_path),
+                archive_member_path=member_name,
+                export_lp_path=str(run_dir / shard_id / f"{tsm_stem}.lp"),
+                discovered_at=_utc_now(),
+            )
+        )
+    return sorted(
         files,
         key=lambda record: (
             record.shard_id,
@@ -391,6 +393,17 @@ def _discover_files(
             record.archive_member_path,
         ),
     )
+
+
+def _discover_files(
+    run_dir: Path,
+    manifest: MigrationManifest,
+    discovered_entries: list[tuple[str, Path, str]],
+    resolved_shards: list[str],
+) -> int:
+    """Populate the manifest with already-discovered shard files."""
+    manifest.shards = resolved_shards
+    manifest.files = _build_discovered_records(run_dir, discovered_entries)
     manifest.status = "discovered"
     _save_manifest(run_dir, manifest)
     return len(manifest.files)
@@ -1229,26 +1242,6 @@ def _required_shard_selection_options[F: Callable[..., Any]](
     )(function)
 
 
-def _optional_shard_selection_options[F: Callable[..., Any]](
-    function: F,
-) -> F:
-    """Add optional shard-selection options."""
-    function = click.option(
-        "--all-shards",
-        is_flag=True,
-        help=(
-            "Use all shards from the all-shards migration run. "
-            "This is the default when no shard selection is given."
-        ),
-    )(function)
-    return click.option(
-        "--shard",
-        "shards",
-        multiple=True,
-        help="Shard ID to include. Repeat for multiple shards.",
-    )(function)
-
-
 def _run_dir_option[F: Callable[..., Any]](function: F) -> F:
     """Add a required migration run directory option."""
     return click.option(
@@ -1278,6 +1271,13 @@ def discover(
         require_selection=True,
         default_all_shards=False,
     )
+    resolved_shards, discovered_entries = _discover_entries(
+        backup_dir=backup_dir,
+        database=database,
+        retention=retention,
+        all_shards=use_all_shards,
+        shards=selection_shards,
+    )
     if run_dir.exists():
         raise click.ClickException(f"Run directory {run_dir} already exists.")
     run_dir.mkdir(parents=True, exist_ok=False)
@@ -1294,12 +1294,17 @@ def discover(
         database=database,
         retention=retention,
         all_shards=use_all_shards,
-        shards=[] if use_all_shards else sorted(selection_shards),
+        shards=[] if use_all_shards else resolved_shards,
         created_at=now,
         updated_at=now,
         status="initialized",
     )
-    discovered_count = _discover_files(run_dir, manifest, backup_dir)
+    discovered_count = _discover_files(
+        run_dir,
+        manifest,
+        discovered_entries,
+        resolved_shards,
+    )
     click.echo(
         "Discovered "
         f"{discovered_count} TSM file(s) in "

--- a/src/sasquatch/tag_to_field.py
+++ b/src/sasquatch/tag_to_field.py
@@ -9,6 +9,7 @@ import click
 from .line_protocol import (
     _extract_measurement_from_series_key,
     _find_unescaped_separator,
+    _is_metadata_line,
     _iter_field_ranges,
     _iter_tag_ranges,
     _rewrite_file_in_place,
@@ -109,8 +110,7 @@ def _convert_tag_to_field_in_line(
     """Convert one tag key into a string field on a single line."""
     line_ending = "\n" if line.endswith("\n") else ""
     content = line.removesuffix(line_ending)
-    stripped_line = content.strip()
-    if not stripped_line or stripped_line.startswith("#"):
+    if _is_metadata_line(content):
         return line
 
     record_parts = _split_record_content(content)

--- a/src/sasquatch/tags.py
+++ b/src/sasquatch/tags.py
@@ -9,6 +9,7 @@ from .line_protocol import (
     _escape_tag_key,
     _extract_measurement_and_tag_keys,
     _find_unescaped_separator,
+    _is_metadata_line,
     _iter_tag_ranges,
     _rewrite_file_in_place,
     _unescape_if_needed,
@@ -23,8 +24,7 @@ def _rename_tag_in_line(
     measurement: str | None = None,
 ) -> str:
     """Rename a tag key in a single line of InfluxDB line protocol."""
-    stripped_line = line.strip()
-    if not stripped_line or stripped_line.startswith("#"):
+    if _is_metadata_line(line):
         return line
 
     field_separator = _find_unescaped_separator(line, " ")
@@ -71,8 +71,7 @@ def _drop_tag_from_line(
     measurement: str | None = None,
 ) -> str:
     """Drop a tag key from a single line of InfluxDB line protocol."""
-    stripped_line = line.strip()
-    if not stripped_line or stripped_line.startswith("#"):
+    if _is_metadata_line(line):
         return line
 
     field_separator = _find_unescaped_separator(line, " ")

--- a/tests/fields_test.py
+++ b/tests/fields_test.py
@@ -8,12 +8,27 @@ from click.testing import CliRunner
 
 from sasquatch.cli import main
 
+EXPORT_HEADER = (
+    "# INFLUXDB EXPORT: 1677-09-21T00:12:43Z - 2262-04-11T23:47:16Z\n"
+    "# DDL\n"
+    'CREATE DATABASE "target.metrics"\n'
+    "# DML\n"
+    "# CONTEXT-DATABASE:target.metrics\n"
+    "# CONTEXT-RETENTION-POLICY:forever\n"
+    "# writing tsm data\n"
+)
+
+
+def _with_header(content: str) -> str:
+    """Prefix synthetic line protocol with a realistic export header."""
+    return EXPORT_HEADER + content
+
 
 def test_show_fields_groups_field_keys_by_measurement(tmp_path: Path) -> None:
     """The CLI should print field keys grouped by measurement."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us temp=82,humidity=41i\ncpu value=1i\n",
+        _with_header("weather,region=us temp=82,humidity=41i\ncpu value=1i\n"),
         encoding="utf-8",
     )
 
@@ -33,7 +48,10 @@ def test_show_fields_handles_quoted_string_values_with_commas_and_spaces(
     """Quoted string field values should not break field parsing."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        'weather,region=us temp=82,summary="hot, dry day",note="clear sky"\n',
+        _with_header(
+            'weather,region=us temp=82,summary="hot, dry day",'
+            'note="clear sky"\n'
+        ),
         encoding="utf-8",
     )
 
@@ -51,10 +69,12 @@ def test_drop_field_rewrites_line_protocol_file(tmp_path: Path) -> None:
     """The CLI should remove matching fields and keep the rest unchanged."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "# comment\n"
-        'weather,region=us temp=82,summary="hot, dry day"\n'
-        "weather,region=us humidity=41i,status=1i\n"
-        "cpu value=1i\n",
+        _with_header(
+            "# comment\n"
+            'weather,region=us temp=82,summary="hot, dry day"\n'
+            "weather,region=us humidity=41i,status=1i\n"
+            "cpu value=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -66,7 +86,7 @@ def test_drop_field_rewrites_line_protocol_file(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "# comment\n"
         "weather,region=us temp=82\n"
         "weather,region=us humidity=41i,status=1i\n"
@@ -80,7 +100,10 @@ def test_drop_field_drops_lines_with_no_remaining_fields(
     """Dropping the only field should remove the whole record line."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us temp=82\nweather,region=us humidity=41i,temp=83\n",
+        _with_header(
+            "weather,region=us temp=82\n"
+            "weather,region=us humidity=41i,temp=83\n"
+        ),
         encoding="utf-8",
     )
 
@@ -91,7 +114,7 @@ def test_drop_field_drops_lines_with_no_remaining_fields(
     )
 
     assert result.exit_code == 0
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather,region=us humidity=41i\n"
     )
 
@@ -102,9 +125,11 @@ def test_drop_field_verbose_reports_modified_line_count(
     """Verbose mode should report how many lines changed."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather temp=82,humidity=41i\n"
-        'weather summary="hot, dry day",status=1i\n'
-        "cpu value=1i\n",
+        _with_header(
+            "weather temp=82,humidity=41i\n"
+            'weather summary="hot, dry day",status=1i\n'
+            "cpu value=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -123,7 +148,7 @@ def test_drop_field_verbose_reports_modified_line_count(
 
     assert result.exit_code == 0
     assert result.output == "Modified 1 lines.\n"
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather temp=82,humidity=41i\nweather status=1i\ncpu value=1i\n"
     )
 
@@ -132,9 +157,11 @@ def test_drop_field_can_be_scoped_to_one_measurement(tmp_path: Path) -> None:
     """Measurement scoping should preserve matching fields elsewhere."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather temp=82,humidity=41i\n"
-        "cpu temp=55i,value=1i\n"
-        'weather summary="hot, dry day",status=1i\n',
+        _with_header(
+            "weather temp=82,humidity=41i\n"
+            "cpu temp=55i,value=1i\n"
+            'weather summary="hot, dry day",status=1i\n'
+        ),
         encoding="utf-8",
     )
 
@@ -154,7 +181,7 @@ def test_drop_field_can_be_scoped_to_one_measurement(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather humidity=41i\n"
         "cpu temp=55i,value=1i\n"
         'weather summary="hot, dry day",status=1i\n'
@@ -167,9 +194,11 @@ def test_drop_field_verbose_reports_scoped_line_count(
     """Count only modified lines in the target measurement."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather temp=82,humidity=41i\n"
-        "cpu temp=55i,value=1i\n"
-        "weather temp=83,status=1i\n",
+        _with_header(
+            "weather temp=82,humidity=41i\n"
+            "cpu temp=55i,value=1i\n"
+            "weather temp=83,status=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -190,7 +219,7 @@ def test_drop_field_verbose_reports_scoped_line_count(
 
     assert result.exit_code == 0
     assert result.output == "Modified 2 lines.\n"
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather humidity=41i\ncpu temp=55i,value=1i\nweather status=1i\n"
     )
 
@@ -199,9 +228,11 @@ def test_rename_field_rewrites_line_protocol_file(tmp_path: Path) -> None:
     """The CLI should rename matching fields and keep the rest unchanged."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "# comment\n"
-        'weather temp=82,summary="hot, dry day"\n'
-        "cpu temp=55i,value=1i\n",
+        _with_header(
+            "# comment\n"
+            'weather temp=82,summary="hot, dry day"\n'
+            "cpu temp=55i,value=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -220,7 +251,7 @@ def test_rename_field_rewrites_line_protocol_file(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "# comment\n"
         'weather temperature=82,summary="hot, dry day"\n'
         "cpu temperature=55i,value=1i\n"
@@ -231,9 +262,11 @@ def test_rename_field_can_be_scoped_to_one_measurement(tmp_path: Path) -> None:
     """Measurement scoping should preserve matching fields elsewhere."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather temp=82,humidity=41i\n"
-        "cpu temp=55i,value=1i\n"
-        "weather temp=83,status=1i\n",
+        _with_header(
+            "weather temp=82,humidity=41i\n"
+            "cpu temp=55i,value=1i\n"
+            "weather temp=83,status=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -254,7 +287,7 @@ def test_rename_field_can_be_scoped_to_one_measurement(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather temperature=82,humidity=41i\n"
         "cpu temp=55i,value=1i\n"
         "weather temperature=83,status=1i\n"
@@ -267,7 +300,7 @@ def test_rename_field_escapes_new_key_and_reports_verbose_count(
     """Verbose mode should report changes and escaped new keys stay valid."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather temp=82,humidity=41i\ncpu temp=55i,value=1i\n",
+        _with_header("weather temp=82,humidity=41i\ncpu temp=55i,value=1i\n"),
         encoding="utf-8",
     )
 
@@ -289,6 +322,6 @@ def test_rename_field_escapes_new_key_and_reports_verbose_count(
 
     assert result.exit_code == 0
     assert result.output == "Modified 1 lines.\n"
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather temperature\\ zone=82,humidity=41i\ncpu temp=55i,value=1i\n"
     )

--- a/tests/fields_test.py
+++ b/tests/fields_test.py
@@ -20,7 +20,7 @@ def test_show_fields_groups_field_keys_by_measurement(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "show-fields", str(data_file)],
+        ["influxdb", "line-protocol", "show-fields", str(data_file)],
     )
 
     assert result.exit_code == 0
@@ -40,7 +40,7 @@ def test_show_fields_handles_quoted_string_values_with_commas_and_spaces(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "show-fields", str(data_file)],
+        ["influxdb", "line-protocol", "show-fields", str(data_file)],
     )
 
     assert result.exit_code == 0
@@ -61,7 +61,7 @@ def test_drop_field_rewrites_line_protocol_file(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "drop-field", str(data_file), "summary"],
+        ["influxdb", "line-protocol", "drop-field", str(data_file), "summary"],
     )
 
     assert result.exit_code == 0
@@ -87,7 +87,7 @@ def test_drop_field_drops_lines_with_no_remaining_fields(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "drop-field", str(data_file), "temp"],
+        ["influxdb", "line-protocol", "drop-field", str(data_file), "temp"],
     )
 
     assert result.exit_code == 0
@@ -111,7 +111,14 @@ def test_drop_field_verbose_reports_modified_line_count(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "drop-field", "-v", str(data_file), "summary"],
+        [
+            "influxdb",
+            "line-protocol",
+            "drop-field",
+            "-v",
+            str(data_file),
+            "summary",
+        ],
     )
 
     assert result.exit_code == 0
@@ -136,6 +143,7 @@ def test_drop_field_can_be_scoped_to_one_measurement(tmp_path: Path) -> None:
         main,
         [
             "influxdb",
+            "line-protocol",
             "drop-field",
             "--measurement",
             "weather",
@@ -170,6 +178,7 @@ def test_drop_field_verbose_reports_scoped_line_count(
         main,
         [
             "influxdb",
+            "line-protocol",
             "drop-field",
             "-v",
             "-m",
@@ -199,7 +208,14 @@ def test_rename_field_rewrites_line_protocol_file(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "rename-field", str(data_file), "temp", "temperature"],
+        [
+            "influxdb",
+            "line-protocol",
+            "rename-field",
+            str(data_file),
+            "temp",
+            "temperature",
+        ],
     )
 
     assert result.exit_code == 0
@@ -226,6 +242,7 @@ def test_rename_field_can_be_scoped_to_one_measurement(tmp_path: Path) -> None:
         main,
         [
             "influxdb",
+            "line-protocol",
             "rename-field",
             "--measurement",
             "weather",
@@ -259,6 +276,7 @@ def test_rename_field_escapes_new_key_and_reports_verbose_count(
         main,
         [
             "influxdb",
+            "line-protocol",
             "rename-field",
             "-v",
             "-m",

--- a/tests/measurements_test.py
+++ b/tests/measurements_test.py
@@ -8,6 +8,21 @@ from click.testing import CliRunner
 
 from sasquatch.cli import main
 
+EXPORT_HEADER = (
+    "# INFLUXDB EXPORT: 1677-09-21T00:12:43Z - 2262-04-11T23:47:16Z\n"
+    "# DDL\n"
+    'CREATE DATABASE "target.metrics"\n'
+    "# DML\n"
+    "# CONTEXT-DATABASE:target.metrics\n"
+    "# CONTEXT-RETENTION-POLICY:forever\n"
+    "# writing tsm data\n"
+)
+
+
+def _with_header(content: str) -> str:
+    """Prefix synthetic line protocol with a realistic export header."""
+    return EXPORT_HEADER + content
+
 
 def test_show_measurements_lists_tag_keys_and_field_keys(
     tmp_path: Path,
@@ -15,7 +30,9 @@ def test_show_measurements_lists_tag_keys_and_field_keys(
     """The CLI should print measurements with tag and field keys."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us,zone=north temp=82,humidity=41i\ncpu value=1i\n",
+        _with_header(
+            "weather,region=us,zone=north temp=82,humidity=41i\ncpu value=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -38,7 +55,10 @@ def test_show_measurements_handles_escaped_names_and_quoted_field_values(
     """Escaped tag names and quoted field values should parse cleanly."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        'weather\\ station,tag\\,key=value summary="hot, dry day",temp=82\n',
+        _with_header(
+            "weather\\ station,tag\\,key=value "
+            'summary="hot, dry day",temp=82\n'
+        ),
         encoding="utf-8",
     )
 
@@ -58,10 +78,12 @@ def test_drop_measurement_rewrites_line_protocol_file(tmp_path: Path) -> None:
     """The CLI should remove only matching measurement records."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "# comment\n"
-        "weather,region=us temp=82\n"
-        "cpu value=1i\n"
-        "weather,region=eu humidity=41\n",
+        _with_header(
+            "# comment\n"
+            "weather,region=us temp=82\n"
+            "cpu value=1i\n"
+            "weather,region=eu humidity=41\n"
+        ),
         encoding="utf-8",
     )
 
@@ -79,7 +101,7 @@ def test_drop_measurement_rewrites_line_protocol_file(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "# comment\ncpu value=1i\n"
     )
 
@@ -90,7 +112,7 @@ def test_drop_measurement_matches_unescaped_measurement_name(
     """Escaped measurement names should be matched by their unescaped form."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather\\ station,region=us temp=82\ncpu value=1i\n",
+        _with_header("weather\\ station,region=us temp=82\ncpu value=1i\n"),
         encoding="utf-8",
     )
 
@@ -107,7 +129,9 @@ def test_drop_measurement_matches_unescaped_measurement_name(
     )
 
     assert result.exit_code == 0
-    assert data_file.read_text(encoding="utf-8") == "cpu value=1i\n"
+    assert data_file.read_text(encoding="utf-8") == _with_header(
+        "cpu value=1i\n"
+    )
 
 
 def test_drop_measurement_verbose_reports_modified_line_count(
@@ -116,9 +140,11 @@ def test_drop_measurement_verbose_reports_modified_line_count(
     """Verbose mode should report how many lines changed."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us temp=82\n"
-        "cpu value=1i\n"
-        "weather,region=eu humidity=41\n",
+        _with_header(
+            "weather,region=us temp=82\n"
+            "cpu value=1i\n"
+            "weather,region=eu humidity=41\n"
+        ),
         encoding="utf-8",
     )
 
@@ -137,7 +163,9 @@ def test_drop_measurement_verbose_reports_modified_line_count(
 
     assert result.exit_code == 0
     assert result.output == "Modified 2 lines.\n"
-    assert data_file.read_text(encoding="utf-8") == "cpu value=1i\n"
+    assert data_file.read_text(encoding="utf-8") == _with_header(
+        "cpu value=1i\n"
+    )
 
 
 def test_rename_measurement_rewrites_line_protocol_file(
@@ -146,10 +174,12 @@ def test_rename_measurement_rewrites_line_protocol_file(
     """The CLI should rename only matching measurement records."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "# comment\n"
-        "weather,region=us temp=82\n"
-        "cpu value=1i\n"
-        "weather,region=eu humidity=41\n",
+        _with_header(
+            "# comment\n"
+            "weather,region=us temp=82\n"
+            "cpu value=1i\n"
+            "weather,region=eu humidity=41\n"
+        ),
         encoding="utf-8",
     )
 
@@ -168,7 +198,7 @@ def test_rename_measurement_rewrites_line_protocol_file(
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "# comment\n"
         "forecast,region=us temp=82\n"
         "cpu value=1i\n"
@@ -182,7 +212,7 @@ def test_rename_measurement_matches_unescaped_measurement_name(
     """Escaped measurement names should be matched by their unescaped form."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather\\ station,region=us temp=82\ncpu value=1i\n",
+        _with_header("weather\\ station,region=us temp=82\ncpu value=1i\n"),
         encoding="utf-8",
     )
 
@@ -200,7 +230,7 @@ def test_rename_measurement_matches_unescaped_measurement_name(
     )
 
     assert result.exit_code == 0
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "station\\ forecast,region=us temp=82\ncpu value=1i\n"
     )
 
@@ -211,9 +241,11 @@ def test_rename_measurement_verbose_reports_modified_line_count(
     """Verbose mode should report how many lines changed."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us temp=82\n"
-        "cpu value=1i\n"
-        "weather,region=eu humidity=41\n",
+        _with_header(
+            "weather,region=us temp=82\n"
+            "cpu value=1i\n"
+            "weather,region=eu humidity=41\n"
+        ),
         encoding="utf-8",
     )
 
@@ -233,7 +265,7 @@ def test_rename_measurement_verbose_reports_modified_line_count(
 
     assert result.exit_code == 0
     assert result.output == "Modified 2 lines.\n"
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "forecast,region=us temp=82\n"
         "cpu value=1i\n"
         "forecast,region=eu humidity=41\n"

--- a/tests/measurements_test.py
+++ b/tests/measurements_test.py
@@ -22,7 +22,7 @@ def test_show_measurements_lists_tag_keys_and_field_keys(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "show-measurements", str(data_file)],
+        ["influxdb", "line-protocol", "show-measurements", str(data_file)],
     )
 
     assert result.exit_code == 0
@@ -45,7 +45,7 @@ def test_show_measurements_handles_escaped_names_and_quoted_field_values(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "show-measurements", str(data_file)],
+        ["influxdb", "line-protocol", "show-measurements", str(data_file)],
     )
 
     assert result.exit_code == 0
@@ -68,7 +68,13 @@ def test_drop_measurement_rewrites_line_protocol_file(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "drop-measurement", str(data_file), "weather"],
+        [
+            "influxdb",
+            "line-protocol",
+            "drop-measurement",
+            str(data_file),
+            "weather",
+        ],
     )
 
     assert result.exit_code == 0
@@ -91,7 +97,13 @@ def test_drop_measurement_matches_unescaped_measurement_name(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "drop-measurement", str(data_file), "weather station"],
+        [
+            "influxdb",
+            "line-protocol",
+            "drop-measurement",
+            str(data_file),
+            "weather station",
+        ],
     )
 
     assert result.exit_code == 0
@@ -113,7 +125,14 @@ def test_drop_measurement_verbose_reports_modified_line_count(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "drop-measurement", "-v", str(data_file), "weather"],
+        [
+            "influxdb",
+            "line-protocol",
+            "drop-measurement",
+            "-v",
+            str(data_file),
+            "weather",
+        ],
     )
 
     assert result.exit_code == 0
@@ -139,6 +158,7 @@ def test_rename_measurement_rewrites_line_protocol_file(
         main,
         [
             "influxdb",
+            "line-protocol",
             "rename-measurement",
             str(data_file),
             "weather",
@@ -171,6 +191,7 @@ def test_rename_measurement_matches_unescaped_measurement_name(
         main,
         [
             "influxdb",
+            "line-protocol",
             "rename-measurement",
             str(data_file),
             "weather station",
@@ -201,6 +222,7 @@ def test_rename_measurement_verbose_reports_modified_line_count(
         main,
         [
             "influxdb",
+            "line-protocol",
             "rename-measurement",
             "-v",
             str(data_file),

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import tarfile
 from pathlib import Path
+from typing import Any
 
+import pytest
 from click.testing import CliRunner
 
 from sasquatch.cli import main
@@ -16,23 +19,23 @@ def _create_backup_tree(tmp_path: Path) -> Path:
     backup_dir = tmp_path / "sasquatch-influxdb-oss-full-20260424T050007Z"
     backup_dir.mkdir()
 
-    archive_path = backup_dir / "20260424T050008Z.s997.tar.gz"
+    archive_path = backup_dir / "20260424T050008Z.s975.tar.gz"
     source_dir = tmp_path / "source"
-    shard_dir = source_dir / "lsst.square.metrics" / "autogen" / "997"
+    shard_dir = source_dir / "lsst.square.metrics" / "autogen" / "975"
     shard_dir.mkdir(parents=True)
-    tsm_path = shard_dir / "000000009-000000002.tsm"
+    tsm_path = shard_dir / "000000008-000000002.tsm"
     tsm_path.write_text("placeholder", encoding="utf-8")
 
     with tarfile.open(archive_path, "w:gz") as archive:
         archive.add(
             tsm_path,
-            arcname="lsst.square.metrics/autogen/997/000000009-000000002.tsm",
+            arcname="lsst.square.metrics/autogen/975/000000008-000000002.tsm",
         )
 
     return backup_dir
 
 
-def _read_manifest(work_dir: Path) -> dict[str, object]:
+def _read_manifest(work_dir: Path) -> dict[str, Any]:
     """Load the discover manifest from a work directory."""
     manifests = list(work_dir.rglob("migration-manifest.json"))
     assert len(manifests) == 1
@@ -58,7 +61,7 @@ def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
             "--retention",
             "autogen",
             "--shard",
-            "997",
+            "975",
             "--work-dir",
             str(work_dir),
         ],
@@ -70,7 +73,7 @@ def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
     manifest = _read_manifest(work_dir)
     assert manifest["database"] == "lsst.square.metrics"
     assert manifest["retention"] == "autogen"
-    assert manifest["shards"] == ["997"]
+    assert manifest["shards"] == ["975"]
     assert manifest["status"] == "discovered"
     assert len(manifest["files"]) == 1
     assert _read_manifest(
@@ -122,7 +125,7 @@ def test_migrate_discover_rejects_missing_shard(tmp_path: Path) -> None:
 
 
 def test_migrate_discover_real_sample_data(tmp_path: Path) -> None:
-    """Discover should find the three sample shards shipped in the repo."""
+    """Discover should find the sample shard shipped in the repo."""
     backup_dir = (
         Path(__file__).resolve().parents[1]
         / "data"
@@ -145,25 +148,150 @@ def test_migrate_discover_real_sample_data(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--shard",
-            "986",
-            "--shard",
-            "997",
             "--work-dir",
             str(work_dir),
         ],
     )
 
     assert result.exit_code == 0
-    assert result.output == "Discovered 3 TSM file(s) in 3 shard(s).\n"
+    assert result.output == "Discovered 1 TSM file(s) in 1 shard(s).\n"
 
     manifest = _read_manifest(work_dir)
-    assert manifest["shards"] == ["975", "986", "997"]
+    assert manifest["shards"] == ["975"]
     member_paths = [
         record["archive_member_path"] for record in manifest["files"]
     ]
     assert member_paths == [
         "lsst.square.metrics/autogen/975/000000008-000000002.tsm",
-        "lsst.square.metrics/autogen/986/000000009-000000002.tsm",
-        "lsst.square.metrics/autogen/997/000000009-000000002.tsm",
     ]
+
+
+def test_migrate_export_updates_manifest_and_writes_lp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Export should stage TSM files and write LP output."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert capture_output is True
+        assert check is False
+        assert text is True
+        assert argv[0] == "influx_inspect"
+        out_path = Path(argv[argv.index("-out") + 1])
+        tsm_path = Path(argv[argv.index("-tsmfile") + 1])
+        assert tsm_path.exists()
+        out_path.write_text(
+            "weather,region=us temp=82\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(argv, 0, "exported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = CliRunner()
+
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+
+    export_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "export",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert export_result.exit_code == 0
+    assert export_result.output == "Exported 1 file(s).\n"
+
+    manifest = _read_manifest(work_dir)
+    assert manifest["status"] == "exported"
+    file_record = manifest["files"][0]
+    assert file_record["exported_at"] is not None
+    assert file_record["extracted_tsm_path"] is not None
+    assert file_record["export_log_path"] is not None
+    export_lp_path = Path(file_record["export_lp_path"])
+    assert export_lp_path.read_text(encoding="utf-8") == (
+        "weather,region=us temp=82\n"
+    )
+
+
+def test_migrate_export_discovers_when_manifest_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Export should perform discovery first when no manifest exists yet."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        out_path = Path(argv[argv.index("-out") + 1])
+        out_path.write_text("cpu value=1i\n", encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, "exported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "export",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    manifest = _read_manifest(work_dir)
+    assert manifest["status"] == "exported"
+    assert len(manifest["files"]) == 1

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -42,6 +42,15 @@ def _read_manifest(work_dir: Path) -> dict[str, Any]:
     return json.loads(manifests[0].read_text(encoding="utf-8"))
 
 
+def _write_exported_lp(work_dir: Path, content: str) -> Path:
+    """Write exported line protocol content for the current manifest."""
+    manifest = _read_manifest(work_dir)
+    export_lp_path = Path(manifest["files"][0]["export_lp_path"])
+    export_lp_path.parent.mkdir(parents=True, exist_ok=True)
+    export_lp_path.write_text(content, encoding="utf-8")
+    return export_lp_path
+
+
 def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
     """Discover should create a manifest from shard archives."""
     backup_dir = _create_backup_tree(tmp_path)
@@ -295,3 +304,559 @@ def test_migrate_export_discovers_when_manifest_is_empty(
     manifest = _read_manifest(work_dir)
     assert manifest["status"] == "exported"
     assert len(manifest["files"]) == 1
+
+
+def test_migrate_transform_updates_manifest_and_rewrites_lp(
+    tmp_path: Path,
+) -> None:
+    """Transform should apply a YAML plan and update manifest state."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(
+        "- op: drop-tag\n  tag: region\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+
+    export_lp_path = _write_exported_lp(
+        work_dir,
+        "weather,region=us temp=82\n",
+    )
+
+    transform_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert transform_result.exit_code == 0
+    assert transform_result.output == "Transformed 1 file(s).\n"
+    assert export_lp_path.read_text(encoding="utf-8") == "weather temp=82\n"
+
+    manifest = _read_manifest(work_dir)
+    assert manifest["status"] == "transformed"
+    assert manifest["transform_plan_path"] == str(plan_path)
+    assert manifest["transform_plan_hash"] is not None
+    assert manifest["files"][0]["transformed_at"] is not None
+
+
+def test_migrate_transform_skips_already_transformed_files(
+    tmp_path: Path,
+) -> None:
+    """Transform should skip files already marked transformed."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(
+        "- op: drop-tag\n  tag: region\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    export_lp_path = _write_exported_lp(
+        work_dir,
+        "weather,region=us temp=82\n",
+    )
+
+    first_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+    assert first_result.exit_code == 0
+
+    export_lp_path.write_text("weather temp=82\n", encoding="utf-8")
+    second_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert second_result.exit_code == 0
+    assert second_result.output == "Transformed 0 file(s).\n"
+    assert export_lp_path.read_text(encoding="utf-8") == "weather temp=82\n"
+
+
+def test_migrate_transform_reapplies_with_force(tmp_path: Path) -> None:
+    """Transform should rerun a plan when --force is supplied."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    first_plan = tmp_path / "drop-tag.yaml"
+    first_plan.write_text(
+        "- op: drop-tag\n  tag: region\n",
+        encoding="utf-8",
+    )
+    second_plan = tmp_path / "rename-measurement.yaml"
+    second_plan.write_text(
+        "- op: rename-measurement\n  from: weather\n  to: climate\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    export_lp_path = _write_exported_lp(
+        work_dir,
+        "weather,region=us temp=82\n",
+    )
+
+    first_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(first_plan),
+        ],
+    )
+    assert first_result.exit_code == 0
+
+    second_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(second_plan),
+            "--force",
+        ],
+    )
+
+    assert second_result.exit_code == 0
+    assert export_lp_path.read_text(encoding="utf-8") == "climate temp=82\n"
+
+
+def test_migrate_transform_rejects_invalid_plan_extension(
+    tmp_path: Path,
+) -> None:
+    """Transform should require a YAML extension."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text("[]", encoding="utf-8")
+
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    _write_exported_lp(work_dir, "weather,region=us temp=82\n")
+
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Transform plan must use a .yaml or .yml extension." in result.output
+    )
+
+
+def test_migrate_transform_rejects_unknown_operation(tmp_path: Path) -> None:
+    """Transform should reject unknown operations in the YAML plan."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(
+        "- op: surprise\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    _write_exported_lp(work_dir, "weather,region=us temp=82\n")
+
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Unknown transform operation 'surprise'." in result.output
+
+
+def test_migrate_transform_requires_exported_file(tmp_path: Path) -> None:
+    """Transform should fail when the exported LP file is missing."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(
+        "- op: drop-tag\n  tag: region\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "is missing. Run export first." in result.output
+
+
+def test_migrate_transform_rejects_changed_plan_without_force(
+    tmp_path: Path,
+) -> None:
+    """Transform should reject a changed plan hash unless forced."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    first_plan = tmp_path / "first.yaml"
+    first_plan.write_text(
+        "- op: drop-tag\n  tag: region\n",
+        encoding="utf-8",
+    )
+    second_plan = tmp_path / "second.yaml"
+    second_plan.write_text(
+        "- op: rename-measurement\n  from: weather\n  to: climate\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    _write_exported_lp(work_dir, "weather,region=us temp=82\n")
+
+    first_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(first_plan),
+        ],
+    )
+    assert first_result.exit_code == 0
+
+    second_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(second_plan),
+        ],
+    )
+
+    assert second_result.exit_code != 0
+    assert (
+        "Transform plan changed for an existing run." in second_result.output
+    )
+
+
+def test_migrate_transform_reports_tag_to_field_conflicts(
+    tmp_path: Path,
+) -> None:
+    """Transform should surface tag-to-field conflicts."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(
+        "- op: convert-tag-to-field\n  tag: region\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    _write_exported_lp(work_dir, 'weather,region=us region="west"\n')
+
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    manifest = _read_manifest(work_dir)
+    assert manifest["files"][0]["last_error"] is not None

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -233,6 +233,7 @@ def test_migrate_export_updates_manifest_and_writes_lp(
         assert check is False
         assert text is True
         assert argv[0] == "influx_inspect"
+        assert "-lponly" not in argv
         out_path = Path(argv[argv.index("-out") + 1])
         tsm_path = Path(argv[argv.index("-tsmfile") + 1])
         assert tsm_path.exists()

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -81,6 +81,17 @@ def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
     assert run_dir.name.count("--") == 2
 
 
+def test_influxdb_help_shows_line_protocol_and_migrate_groups() -> None:
+    """The InfluxDB CLI should separate line protocol and migration tools."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["influxdb", "--help"])
+
+    assert result.exit_code == 0
+    assert "line-protocol" in result.output
+    assert "migrate" in result.output
+    assert "drop-tag" not in result.output
+
+
 def test_migrate_discover_rejects_missing_shard(tmp_path: Path) -> None:
     """Discover should fail when a requested shard is not present."""
     backup_dir = _create_backup_tree(tmp_path)

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -1,0 +1,158 @@
+"""Tests for migration CLI commands."""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from sasquatch.cli import main
+
+
+def _create_backup_tree(tmp_path: Path) -> Path:
+    """Create a synthetic backup directory with shard archives."""
+    backup_dir = tmp_path / "sasquatch-influxdb-oss-full-20260424T050007Z"
+    backup_dir.mkdir()
+
+    archive_path = backup_dir / "20260424T050008Z.s997.tar.gz"
+    source_dir = tmp_path / "source"
+    shard_dir = source_dir / "lsst.square.metrics" / "autogen" / "997"
+    shard_dir.mkdir(parents=True)
+    tsm_path = shard_dir / "000000009-000000002.tsm"
+    tsm_path.write_text("placeholder", encoding="utf-8")
+
+    with tarfile.open(archive_path, "w:gz") as archive:
+        archive.add(
+            tsm_path,
+            arcname="lsst.square.metrics/autogen/997/000000009-000000002.tsm",
+        )
+
+    return backup_dir
+
+
+def _read_manifest(work_dir: Path) -> dict[str, object]:
+    """Load the discover manifest from a work directory."""
+    manifests = list(work_dir.rglob("migration-manifest.json"))
+    assert len(manifests) == 1
+    return json.loads(manifests[0].read_text(encoding="utf-8"))
+
+
+def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
+    """Discover should create a manifest from shard archives."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "997",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Discovered 1 TSM file(s) in 1 shard(s).\n"
+
+    manifest = _read_manifest(work_dir)
+    assert manifest["database"] == "lsst.square.metrics"
+    assert manifest["retention"] == "autogen"
+    assert manifest["shards"] == ["997"]
+    assert manifest["status"] == "discovered"
+    assert len(manifest["files"]) == 1
+    assert _read_manifest(
+        work_dir
+    )  # manifest exists under the shortened run dir
+    run_dir = next(work_dir.iterdir())
+    assert run_dir.name.startswith("lsst.square.metrics--autogen--")
+    assert run_dir.name.count("--") == 2
+
+
+def test_migrate_discover_rejects_missing_shard(tmp_path: Path) -> None:
+    """Discover should fail when a requested shard is not present."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "998",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "No TSM files found for shard '998'" in result.output
+
+
+def test_migrate_discover_real_sample_data(tmp_path: Path) -> None:
+    """Discover should find the three sample shards shipped in the repo."""
+    backup_dir = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "sasquatch-influxdb-oss-full-20260421T050014Z"
+    )
+    work_dir = tmp_path / "work"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--shard",
+            "986",
+            "--shard",
+            "997",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Discovered 3 TSM file(s) in 3 shard(s).\n"
+
+    manifest = _read_manifest(work_dir)
+    assert manifest["shards"] == ["975", "986", "997"]
+    member_paths = [
+        record["archive_member_path"] for record in manifest["files"]
+    ]
+    assert member_paths == [
+        "lsst.square.metrics/autogen/975/000000008-000000002.tsm",
+        "lsst.square.metrics/autogen/986/000000009-000000002.tsm",
+        "lsst.square.metrics/autogen/997/000000009-000000002.tsm",
+    ]

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -51,6 +51,45 @@ def _write_exported_lp(work_dir: Path, content: str) -> Path:
     return export_lp_path
 
 
+def _mark_transformed(work_dir: Path) -> None:
+    """Mark the manifest file as transformed for import tests."""
+    manifest_path = next(work_dir.rglob("migration-manifest.json"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["status"] = "transformed"
+    manifest["files"][0]["transformed_at"] = "2026-04-29T00:00:00+00:00"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _discover_source_run(
+    runner: CliRunner,
+    backup_dir: Path,
+    work_dir: Path,
+) -> None:
+    """Create a manifest using the source database and retention."""
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert result.exit_code == 0
+
+
 def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
     """Discover should create a manifest from shard archives."""
     backup_dir = _create_backup_tree(tmp_path)
@@ -860,3 +899,325 @@ def test_migrate_transform_reports_tag_to_field_conflicts(
     assert result.exit_code != 0
     manifest = _read_manifest(work_dir)
     assert manifest["files"][0]["last_error"] is not None
+
+
+def test_migrate_import_updates_manifest_and_rewrites_headers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should rewrite headers and update import state."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    _discover_source_run(runner, backup_dir, work_dir)
+    file_path = _write_exported_lp(
+        work_dir,
+        "# DML\n"
+        "# CONTEXT-DATABASE: lsst.square.metrics\n"
+        "# CONTEXT-RETENTION-POLICY: autogen\n"
+        "weather temp=82\n",
+    )
+    _mark_transformed(work_dir)
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert argv[0] == "influx"
+        assert "-host" in argv
+        assert "-import" in argv
+        return subprocess.CompletedProcess(argv, 0, "imported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--host",
+            "influxdb.example.org",
+            "--target-database",
+            "target.metrics",
+            "--target-retention",
+            "forever",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Updated import headers in" in result.output
+    assert "Imported 1 file(s)." in result.output
+    content = file_path.read_text(encoding="utf-8")
+    assert "# CONTEXT-DATABASE: target.metrics\n" in content
+    assert "# CONTEXT-RETENTION-POLICY: forever\n" in content
+    manifest = _read_manifest(work_dir)
+    assert manifest["status"] == "imported"
+    assert manifest["files"][0]["imported_at"] is not None
+    assert manifest["files"][0]["import_log_path"] is not None
+
+
+def test_migrate_import_adds_missing_headers_and_reports_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should add missing DML headers."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    _discover_source_run(runner, backup_dir, work_dir)
+    file_path = _write_exported_lp(work_dir, "weather temp=82\n")
+    _mark_transformed(work_dir)
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 0, "imported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--host",
+            "influxdb.example.org",
+            "--target-database",
+            "target.metrics",
+            "--target-retention",
+            "forever",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Added import headers to" in result.output
+    content = file_path.read_text(encoding="utf-8")
+    assert content.startswith(
+        "# DML\n"
+        "# CONTEXT-DATABASE: target.metrics\n"
+        "# CONTEXT-RETENTION-POLICY: forever\n"
+    )
+
+
+def test_migrate_import_is_quiet_when_headers_already_match(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should not print per-file header output when unchanged."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    _discover_source_run(runner, backup_dir, work_dir)
+    _write_exported_lp(
+        work_dir,
+        "# DML\n"
+        "# CONTEXT-DATABASE: target.metrics\n"
+        "# CONTEXT-RETENTION-POLICY: forever\n"
+        "weather temp=82\n",
+    )
+    _mark_transformed(work_dir)
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 0, "imported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--host",
+            "influxdb.example.org",
+            "--target-database",
+            "target.metrics",
+            "--target-retention",
+            "forever",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Imported 1 file(s).\n"
+
+
+def test_migrate_import_skips_already_imported_without_force(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should skip files already marked imported."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    _discover_source_run(runner, backup_dir, work_dir)
+    _write_exported_lp(work_dir, "weather temp=82\n")
+    _mark_transformed(work_dir)
+    manifest_path = next(work_dir.rglob("migration-manifest.json"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"][0]["imported_at"] = "2026-04-29T00:00:00+00:00"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    calls = 0
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        return subprocess.CompletedProcess(argv, 0, "imported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--host",
+            "influxdb.example.org",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Imported 0 file(s).\n"
+    assert calls == 0
+
+
+def test_migrate_import_requires_transformed_file(tmp_path: Path) -> None:
+    """Import should fail when transformed_at is missing."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    _discover_source_run(runner, backup_dir, work_dir)
+    _write_exported_lp(work_dir, "weather temp=82\n")
+
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--host",
+            "influxdb.example.org",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "has not been transformed. Run transform first." in result.output
+
+
+def test_migrate_import_records_subprocess_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should record CLI failures in the manifest."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    _discover_source_run(runner, backup_dir, work_dir)
+    _write_exported_lp(work_dir, "weather temp=82\n")
+    _mark_transformed(work_dir)
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 1, "", "boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+            "--host",
+            "influxdb.example.org",
+        ],
+    )
+
+    assert result.exit_code != 0
+    manifest = _read_manifest(work_dir)
+    assert manifest["files"][0]["last_error"] == "boom"

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -213,6 +213,31 @@ def _show_databases_output(*databases: str) -> str:
     return "name: databases\nname\n" + "\n".join(databases) + "\n"
 
 
+MULTILINE_EXPORT_SAMPLE = (
+    "lsst.square.metrics.events.mobu.notebook_cell_execution,"
+    "application=mobu,business=NotebookRunner,"
+    "notebook=/tmp/tmpp7aeb3u4/DP02_01_Introduction_to_DP02.ipynb,"
+    "repo=https://github.com/rubin-dp0/tutorial-notebooks.git,"
+    'repo_ref=prod,success=true,username=bot-mobu-tutorial contents="" '
+    "1734286635377134711\n"
+    "lsst.square.metrics.events.mobu.notebook_cell_execution,"
+    "application=mobu,business=NotebookRunner,"
+    "notebook=/tmp/tmpp7aeb3u4/DP02_01_Introduction_to_DP02.ipynb,"
+    "repo=https://github.com/rubin-dp0/tutorial-notebooks.git,"
+    'repo_ref=prod,success=true,username=bot-mobu-tutorial contents="'
+    "# This is a code cell. Press shift-enter to execute.\n"
+    "# The # makes these lines comments, not code. They are not executed.\n"
+    "print('Hello, world!')\" 1734297667740239680\n"
+    "lsst.square.metrics.events.mobu.notebook_cell_execution,"
+    "application=mobu,business=NotebookRunner,"
+    "notebook=/tmp/tmpp7aeb3u4/DP02_01_Introduction_to_DP02.ipynb,"
+    "repo=https://github.com/rubin-dp0/tutorial-notebooks.git,"
+    'repo_ref=prod,success=true,username=bot-mobu-tutorial contents="'
+    "# ! echo $IMAGE_DESCRIPTION\n"
+    '# ! eups list -s | grep lsst_distrib" 1734297668748888579\n'
+)
+
+
 def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
     """Discover should create a manifest from shard archives."""
     backup_dir = _create_backup_tree(tmp_path)
@@ -283,7 +308,6 @@ def test_migrate_discover_rejects_existing_run_dir(tmp_path: Path) -> None:
     assert result.output == (
         "Running discover...\n"
         f"Error: Run directory {run_dir} already exists.\n"
-        f"Error: Run directory {run_dir} already exists.\n"
     )
 
 
@@ -326,7 +350,6 @@ def test_migrate_discover_rejects_missing_shard(tmp_path: Path) -> None:
     assert result.exit_code != 0
     assert result.output == (
         "Running discover...\n"
-        "Error: No TSM files found for shard '998' in the backup directory.\n"
         "Error: No TSM files found for shard '998' in the backup directory.\n"
     )
     assert not run_dir.exists()
@@ -400,7 +423,6 @@ def test_migrate_discover_all_shards_requires_backup_manifest(
     assert result.exit_code != 0
     assert (
         "Running discover...\n"
-        f"Error: No backup manifest file found in {backup_dir}.\n"
         f"Error: No backup manifest file found in {backup_dir}.\n"
     ) == result.output
     assert not run_dir.exists()
@@ -735,7 +757,6 @@ def test_migrate_export_requires_existing_run_dir(tmp_path: Path) -> None:
     assert result.output == (
         "Running export...\n"
         f"Error: No migration-manifest.json found in {run_dir}.\n"
-        f"Error: No migration-manifest.json found in {run_dir}.\n"
     )
 
 
@@ -759,7 +780,6 @@ def test_migrate_export_requires_manifest(tmp_path: Path) -> None:
     assert result.exit_code != 0
     assert result.output == (
         "Running export...\n"
-        f"Error: No migration-manifest.json found in {run_dir}.\n"
         f"Error: No migration-manifest.json found in {run_dir}.\n"
     )
 
@@ -803,8 +823,73 @@ def test_migrate_export_requires_discovered_files(tmp_path: Path) -> None:
         "Running export...\n"
         "Error: No discovered files found in the manifest. "
         "Run discover first.\n"
-        "Error: No discovered files found in the manifest. "
-        "Run discover first.\n"
+    )
+
+
+def test_migrate_export_verify_rejects_multiline_records(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Export --verify should reject multiline LP records."""
+    backup_dir = _create_backup_tree(tmp_path)
+    run_dir = tmp_path / "run"
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        out_path = Path(argv[argv.index("-out") + 1])
+        out_path.write_text(MULTILINE_EXPORT_SAMPLE, encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, "exported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = CliRunner()
+
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--run-dir",
+            str(run_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+
+    export_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "export",
+            "--run-dir",
+            str(run_dir),
+            "--verify",
+        ],
+    )
+
+    export_record = _read_manifest(run_dir)["files"][0]
+    export_lp_path = Path(export_record["export_lp_path"])
+    assert export_result.exit_code != 0
+    assert export_result.output.startswith("Running export...\n")
+    assert str(export_lp_path) in export_result.output
+    assert "notebook_cell_execution" in export_result.output
+    assert "multiline line protocol record" in export_result.output
+    manifest = _read_manifest(run_dir)
+    assert (
+        "multiline line protocol record" in manifest["files"][0]["last_error"]
     )
 
 
@@ -819,6 +904,7 @@ def test_migrate_export_help_uses_run_dir_only() -> None:
     assert result.exit_code == 0
     assert "--run-dir" in result.output
     assert "--force" in result.output
+    assert "--verify" in result.output
     assert "--backup-dir" not in result.output
     assert "--database" not in result.output
     assert "--retention" not in result.output
@@ -1085,7 +1171,6 @@ def test_migrate_transform_rejects_invalid_plan_extension(
         "Running transform...\n"
         "Error: Transform plan must use a .yaml or .yml extension.\n"
     )
-    assert "Usage: main influxdb migrate transform [OPTIONS]" in result.output
 
 
 def test_migrate_transform_rejects_unknown_operation(tmp_path: Path) -> None:
@@ -1136,7 +1221,6 @@ def test_migrate_transform_rejects_unknown_operation(tmp_path: Path) -> None:
     assert result.exit_code != 0
     assert result.output == (
         "Running transform...\n"
-        "Error: Unknown transform operation 'surprise'.\n"
         "Error: Unknown transform operation 'surprise'.\n"
     )
 
@@ -1190,8 +1274,6 @@ def test_migrate_transform_requires_exported_file(tmp_path: Path) -> None:
     export_lp_path = Path(file_record["export_lp_path"])
     assert result.output == (
         "Running transform...\n"
-        f"Error: Exported file {export_lp_path} "
-        "is missing. Run export first.\n"
         f"Error: Exported file {export_lp_path} "
         "is missing. Run export first.\n"
     )
@@ -1266,8 +1348,6 @@ def test_migrate_transform_rejects_changed_plan_without_force(
     assert second_result.exit_code != 0
     assert second_result.output == (
         "Running transform...\n"
-        "Error: Transform plan changed for an existing run. "
-        "Use --force to reapply it.\n"
         "Error: Transform plan changed for an existing run. "
         "Use --force to reapply it.\n"
     )
@@ -1470,7 +1550,6 @@ def test_migrate_transform_requires_run_dir_manifest(tmp_path: Path) -> None:
     assert result.exit_code != 0
     assert result.output == (
         "Running transform...\n"
-        f"Error: No migration-manifest.json found in {run_dir}.\n"
         f"Error: No migration-manifest.json found in {run_dir}.\n"
     )
 
@@ -1988,8 +2067,6 @@ def test_migrate_import_requires_transformed_file(tmp_path: Path) -> None:
         "Running import...\n"
         f"Error: File {file_path} has not been transformed. "
         "Run transform first.\n"
-        f"Error: File {file_path} has not been transformed. "
-        "Run transform first.\n"
     )
 
 
@@ -2277,7 +2354,6 @@ def test_migrate_import_requires_run_dir_manifest(tmp_path: Path) -> None:
     assert result.exit_code != 0
     assert result.output == (
         "Running import...\n"
-        f"Error: No migration-manifest.json found in {run_dir}.\n"
         f"Error: No migration-manifest.json found in {run_dir}.\n"
     )
 

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -208,6 +208,11 @@ def _discover_source_run(
     assert result.exit_code == 0
 
 
+def _show_databases_output(*databases: str) -> str:
+    """Build a simple influx SHOW DATABASES response body."""
+    return "name: databases\nname\n" + "\n".join(databases) + "\n"
+
+
 def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
     """Discover should create a manifest from shard archives."""
     backup_dir = _create_backup_tree(tmp_path)
@@ -1462,6 +1467,14 @@ def test_migrate_import_updates_manifest_and_rewrites_headers(
     ) -> subprocess.CompletedProcess[str]:
         assert argv[0] == "influx"
         assert "-host" in argv
+        if "-execute" in argv:
+            assert argv[argv.index("-execute") + 1] == "SHOW DATABASES"
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("target.metrics"),
+                "",
+            )
         assert "-import" in argv
         return subprocess.CompletedProcess(argv, 0, "imported", "")
 
@@ -1515,6 +1528,13 @@ def test_migrate_import_adds_missing_headers_and_reports_it(
         check: bool,
         text: bool,
     ) -> subprocess.CompletedProcess[str]:
+        if "-execute" in argv:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("target.metrics"),
+                "",
+            )
         return subprocess.CompletedProcess(argv, 0, "imported", "")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -1545,6 +1565,70 @@ def test_migrate_import_adds_missing_headers_and_reports_it(
     )
 
 
+def test_migrate_import_requires_existing_target_database(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should fail before -import when the target database is absent."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    _discover_source_run(runner, backup_dir, work_dir)
+    run_dir = _manifest_run_dir(work_dir)
+    _write_exported_lp(work_dir, "weather temp=82\n")
+    _mark_transformed(work_dir)
+
+    calls: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        if "-execute" in argv:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("_internal"),
+                "",
+            )
+        pytest.fail(
+            "import should not run when the target database is missing"
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--run-dir",
+            str(run_dir),
+            "--host",
+            "influxdb.example.org",
+            "--target-database",
+            "target.metrics",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert (
+        'Database "target.metrics" does not exist in InfluxDB. '
+        "Create it before running import."
+    ) in result.output
+    manifest = _read_manifest(work_dir)
+    assert manifest["files"][0]["last_error"] == (
+        'Database "target.metrics" does not exist in InfluxDB. '
+        "Create it before running import."
+    )
+    assert len(calls) == 1
+    assert "-execute" in calls[0]
+
+
 def test_migrate_import_is_quiet_when_headers_already_match(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1571,6 +1655,13 @@ def test_migrate_import_is_quiet_when_headers_already_match(
         check: bool,
         text: bool,
     ) -> subprocess.CompletedProcess[str]:
+        if "-execute" in argv:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("target.metrics"),
+                "",
+            )
         return subprocess.CompletedProcess(argv, 0, "imported", "")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -1593,6 +1684,84 @@ def test_migrate_import_is_quiet_when_headers_already_match(
 
     assert result.exit_code == 0
     assert result.output == "Imported 1 file(s).\n"
+
+
+def test_migrate_import_checks_database_with_same_connection_options(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should use the same connection flags for SHOW DATABASES."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    _discover_source_run(runner, backup_dir, work_dir)
+    run_dir = _manifest_run_dir(work_dir)
+    _write_exported_lp(work_dir, "weather temp=82\n")
+    _mark_transformed(work_dir)
+
+    execute_argv: list[str] | None = None
+    import_argv: list[str] | None = None
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal execute_argv, import_argv
+        if "-execute" in argv:
+            execute_argv = argv
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("target.metrics"),
+                "",
+            )
+        import_argv = argv
+        return subprocess.CompletedProcess(argv, 0, "imported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--run-dir",
+            str(run_dir),
+            "--host",
+            "influxdb.example.org",
+            "--port",
+            "8443",
+            "--username",
+            "alice",
+            "--password",
+            "secret",
+            "--ssl",
+            "--unsafe-ssl",
+            "--target-database",
+            "target.metrics",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert execute_argv is not None
+    assert import_argv is not None
+    for flag, value in (
+        ("-host", "influxdb.example.org"),
+        ("-port", "8443"),
+        ("-username", "alice"),
+        ("-password", "secret"),
+    ):
+        assert flag in execute_argv
+        assert execute_argv[execute_argv.index(flag) + 1] == value
+        assert flag in import_argv
+        assert import_argv[import_argv.index(flag) + 1] == value
+    assert "-ssl" in execute_argv
+    assert "-unsafeSsl" in execute_argv
+    assert "-ssl" in import_argv
+    assert "-unsafeSsl" in import_argv
 
 
 def test_migrate_import_skips_already_imported_without_force(
@@ -1626,6 +1795,13 @@ def test_migrate_import_skips_already_imported_without_force(
     ) -> subprocess.CompletedProcess[str]:
         nonlocal calls
         calls += 1
+        if "-execute" in argv:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("lsst.square.metrics"),
+                "",
+            )
         return subprocess.CompletedProcess(argv, 0, "imported", "")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -1645,6 +1821,83 @@ def test_migrate_import_skips_already_imported_without_force(
     assert result.exit_code == 0
     assert result.output == "Imported 0 file(s).\n"
     assert calls == 0
+
+
+def test_migrate_import_checks_repeated_database_only_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should cache database existence checks within one run."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--run-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    run_dir = _manifest_run_dir(work_dir)
+    _write_all_exported_lp(
+        work_dir,
+        {
+            "975": "weather temp=82\n",
+            "986": "cpu value=1i\n",
+        },
+    )
+    _mark_transformed(work_dir)
+
+    show_database_calls = 0
+    import_calls = 0
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal show_database_calls, import_calls
+        if "-execute" in argv:
+            show_database_calls += 1
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("lsst.square.metrics"),
+                "",
+            )
+        import_calls += 1
+        return subprocess.CompletedProcess(argv, 0, "imported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--run-dir",
+            str(run_dir),
+            "--host",
+            "influxdb.example.org",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert show_database_calls == 1
+    assert import_calls == 2
 
 
 def test_migrate_import_requires_transformed_file(tmp_path: Path) -> None:
@@ -1693,6 +1946,13 @@ def test_migrate_import_records_subprocess_failure(
         check: bool,
         text: bool,
     ) -> subprocess.CompletedProcess[str]:
+        if "-execute" in argv:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("lsst.square.metrics"),
+                "",
+            )
         return subprocess.CompletedProcess(argv, 1, "", "boom")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -1712,6 +1972,55 @@ def test_migrate_import_records_subprocess_failure(
     assert result.exit_code != 0
     manifest = _read_manifest(work_dir)
     assert manifest["files"][0]["last_error"] == "boom"
+
+
+def test_migrate_import_reports_show_databases_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should surface SHOW DATABASES failures before importing."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    _discover_source_run(runner, backup_dir, work_dir)
+    run_dir = _manifest_run_dir(work_dir)
+    _write_exported_lp(work_dir, "weather temp=82\n")
+    _mark_transformed(work_dir)
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        if "-execute" in argv:
+            return subprocess.CompletedProcess(argv, 1, "", "cannot connect")
+        pytest.fail("import should not run when SHOW DATABASES fails")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--run-dir",
+            str(run_dir),
+            "--host",
+            "influxdb.example.org",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Failed to list databases in InfluxDB: cannot connect" in result.output
+    )
+    manifest = _read_manifest(work_dir)
+    assert (
+        manifest["files"][0]["last_error"]
+        == "Failed to list databases in InfluxDB: cannot connect"
+    )
 
 
 def test_migrate_import_saves_progress_after_each_file(
@@ -1760,6 +2069,13 @@ def test_migrate_import_saves_progress_after_each_file(
         text: bool,
     ) -> subprocess.CompletedProcess[str]:
         nonlocal calls
+        if "-execute" in argv:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("lsst.square.metrics"),
+                "",
+            )
         calls += 1
         if calls == 1:
             return subprocess.CompletedProcess(argv, 0, "imported", "")
@@ -1836,6 +2152,13 @@ def test_migrate_import_defaults_to_all_shards(
         text: bool,
     ) -> subprocess.CompletedProcess[str]:
         calls.append(argv)
+        if "-execute" in argv:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                _show_databases_output("lsst.square.metrics"),
+                "",
+            )
         return subprocess.CompletedProcess(argv, 0, "imported", "")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -1858,7 +2181,7 @@ def test_migrate_import_defaults_to_all_shards(
         "database=lsst.square.metrics, retention=autogen.\n"
         "Imported 2 file(s).\n"
     )
-    assert len(calls) == 2
+    assert len(calls) == 3
 
 
 def test_migrate_import_requires_run_dir_manifest(tmp_path: Path) -> None:

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -239,7 +239,9 @@ def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    assert result.output == "Discovered 1 TSM file(s) in 1 shard(s).\n"
+    assert result.output == (
+        "Running discover...\nDiscovered 1 TSM file(s) in 1 shard(s).\n"
+    )
 
     manifest = _read_manifest(run_dir)
     assert manifest["database"] == "lsst.square.metrics"
@@ -278,7 +280,11 @@ def test_migrate_discover_rejects_existing_run_dir(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert f"Run directory {run_dir} already exists." in result.output
+    assert result.output == (
+        "Running discover...\n"
+        f"Error: Run directory {run_dir} already exists.\n"
+        f"Error: Run directory {run_dir} already exists.\n"
+    )
 
 
 def test_influxdb_help_shows_line_protocol_and_migrate_groups() -> None:
@@ -318,7 +324,11 @@ def test_migrate_discover_rejects_missing_shard(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "No TSM files found for shard '998'" in result.output
+    assert result.output == (
+        "Running discover...\n"
+        "Error: No TSM files found for shard '998' in the backup directory.\n"
+        "Error: No TSM files found for shard '998' in the backup directory.\n"
+    )
     assert not run_dir.exists()
 
 
@@ -349,7 +359,9 @@ def test_migrate_discover_all_shards_uses_backup_manifest(
     )
 
     assert result.exit_code == 0
-    assert result.output == "Discovered 2 TSM file(s) in 2 shard(s).\n"
+    assert result.output == (
+        "Running discover...\nDiscovered 2 TSM file(s) in 2 shard(s).\n"
+    )
     manifest = _read_manifest(run_dir)
     assert manifest["all_shards"] is True
     assert manifest["shards"] == ["975", "986"]
@@ -386,7 +398,11 @@ def test_migrate_discover_all_shards_requires_backup_manifest(
     )
 
     assert result.exit_code != 0
-    assert "No backup manifest file found" in result.output
+    assert (
+        "Running discover...\n"
+        f"Error: No backup manifest file found in {backup_dir}.\n"
+        f"Error: No backup manifest file found in {backup_dir}.\n"
+    ) == result.output
     assert not run_dir.exists()
 
 
@@ -607,7 +623,9 @@ def test_migrate_discover_real_sample_data(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    assert result.output == "Discovered 1 TSM file(s) in 1 shard(s).\n"
+    assert result.output == (
+        "Running discover...\nDiscovered 1 TSM file(s) in 1 shard(s).\n"
+    )
 
     manifest = _read_manifest(run_dir)
     assert manifest["shards"] == ["975"]
@@ -683,7 +701,7 @@ def test_migrate_export_updates_manifest_and_writes_lp(
     )
 
     assert export_result.exit_code == 0
-    assert export_result.output == "Exported 1 file(s).\n"
+    assert export_result.output == ("Running export...\nExported 1 file(s).\n")
 
     manifest = _read_manifest(run_dir)
     assert manifest["status"] == "exported"
@@ -714,7 +732,11 @@ def test_migrate_export_requires_existing_run_dir(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "No migration-manifest.json found" in result.output
+    assert result.output == (
+        "Running export...\n"
+        f"Error: No migration-manifest.json found in {run_dir}.\n"
+        f"Error: No migration-manifest.json found in {run_dir}.\n"
+    )
 
 
 def test_migrate_export_requires_manifest(tmp_path: Path) -> None:
@@ -735,7 +757,11 @@ def test_migrate_export_requires_manifest(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "No migration-manifest.json found" in result.output
+    assert result.output == (
+        "Running export...\n"
+        f"Error: No migration-manifest.json found in {run_dir}.\n"
+        f"Error: No migration-manifest.json found in {run_dir}.\n"
+    )
 
 
 def test_migrate_export_requires_discovered_files(tmp_path: Path) -> None:
@@ -773,9 +799,12 @@ def test_migrate_export_requires_discovered_files(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert (
-        "No discovered files found in the manifest. Run discover first."
-        in result.output
+    assert result.output == (
+        "Running export...\n"
+        "Error: No discovered files found in the manifest. "
+        "Run discover first.\n"
+        "Error: No discovered files found in the manifest. "
+        "Run discover first.\n"
     )
 
 
@@ -851,7 +880,9 @@ def test_migrate_transform_updates_manifest_and_rewrites_lp(
     )
 
     assert transform_result.exit_code == 0
-    assert transform_result.output == "Transformed 1 file(s).\n"
+    assert transform_result.output == (
+        "Running transform...\nTransformed 1 file(s).\n"
+    )
     assert export_lp_path.read_text(encoding="utf-8") == "weather temp=82\n"
 
     manifest = _read_manifest(work_dir)
@@ -927,7 +958,9 @@ def test_migrate_transform_skips_already_transformed_files(
     )
 
     assert second_result.exit_code == 0
-    assert second_result.output == "Transformed 0 file(s).\n"
+    assert second_result.output == (
+        "Running transform...\nTransformed 0 file(s).\n"
+    )
     assert export_lp_path.read_text(encoding="utf-8") == "weather temp=82\n"
 
 
@@ -1048,9 +1081,11 @@ def test_migrate_transform_rejects_invalid_plan_extension(
     )
 
     assert result.exit_code != 0
-    assert (
-        "Transform plan must use a .yaml or .yml extension." in result.output
+    assert result.output.startswith(
+        "Running transform...\n"
+        "Error: Transform plan must use a .yaml or .yml extension.\n"
     )
+    assert "Usage: main influxdb migrate transform [OPTIONS]" in result.output
 
 
 def test_migrate_transform_rejects_unknown_operation(tmp_path: Path) -> None:
@@ -1099,7 +1134,11 @@ def test_migrate_transform_rejects_unknown_operation(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "Unknown transform operation 'surprise'." in result.output
+    assert result.output == (
+        "Running transform...\n"
+        "Error: Unknown transform operation 'surprise'.\n"
+        "Error: Unknown transform operation 'surprise'.\n"
+    )
 
 
 def test_migrate_transform_requires_exported_file(tmp_path: Path) -> None:
@@ -1147,7 +1186,15 @@ def test_migrate_transform_requires_exported_file(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "is missing. Run export first." in result.output
+    file_record = _read_manifest(work_dir)["files"][0]
+    export_lp_path = Path(file_record["export_lp_path"])
+    assert result.output == (
+        "Running transform...\n"
+        f"Error: Exported file {export_lp_path} "
+        "is missing. Run export first.\n"
+        f"Error: Exported file {export_lp_path} "
+        "is missing. Run export first.\n"
+    )
 
 
 def test_migrate_transform_rejects_changed_plan_without_force(
@@ -1217,8 +1264,12 @@ def test_migrate_transform_rejects_changed_plan_without_force(
     )
 
     assert second_result.exit_code != 0
-    assert (
-        "Transform plan changed for an existing run." in second_result.output
+    assert second_result.output == (
+        "Running transform...\n"
+        "Error: Transform plan changed for an existing run. "
+        "Use --force to reapply it.\n"
+        "Error: Transform plan changed for an existing run. "
+        "Use --force to reapply it.\n"
     )
 
 
@@ -1390,7 +1441,7 @@ def test_migrate_transform_defaults_to_all_shards(
     )
 
     assert result.exit_code == 0
-    assert result.output == "Transformed 2 file(s).\n"
+    assert result.output == ("Running transform...\nTransformed 2 file(s).\n")
     assert file_paths["975"].read_text(encoding="utf-8") == "weather temp=82\n"
     assert file_paths["986"].read_text(encoding="utf-8") == "cpu value=1i\n"
 
@@ -1417,7 +1468,11 @@ def test_migrate_transform_requires_run_dir_manifest(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "No migration-manifest.json found" in result.output
+    assert result.output == (
+        "Running transform...\n"
+        f"Error: No migration-manifest.json found in {run_dir}.\n"
+        f"Error: No migration-manifest.json found in {run_dir}.\n"
+    )
 
 
 def test_migrate_transform_help_uses_run_dir_only() -> None:
@@ -1497,6 +1552,7 @@ def test_migrate_import_updates_manifest_and_rewrites_headers(
     )
 
     assert result.exit_code == 0
+    assert result.output.startswith("Running import...\n")
     assert "Updated import headers in" in result.output
     assert "Imported 1 file(s)." in result.output
     content = file_path.read_text(encoding="utf-8")
@@ -1556,6 +1612,7 @@ def test_migrate_import_adds_missing_headers_and_reports_it(
     )
 
     assert result.exit_code == 0
+    assert result.output.startswith("Running import...\n")
     assert "Added import headers to" in result.output
     content = file_path.read_text(encoding="utf-8")
     assert content.startswith(
@@ -1616,9 +1673,11 @@ def test_migrate_import_requires_existing_target_database(
     )
 
     assert result.exit_code != 0
+    assert result.output.startswith("Running import...\n")
+    assert "Added import headers to" in result.output
     assert (
-        'Database "target.metrics" does not exist in InfluxDB. '
-        "Create it before running import."
+        'Error: Database "target.metrics" does not exist in InfluxDB. '
+        "Create it before running import.\n"
     ) in result.output
     manifest = _read_manifest(work_dir)
     assert manifest["files"][0]["last_error"] == (
@@ -1683,7 +1742,7 @@ def test_migrate_import_is_quiet_when_headers_already_match(
     )
 
     assert result.exit_code == 0
-    assert result.output == "Imported 1 file(s).\n"
+    assert result.output == "Running import...\nImported 1 file(s).\n"
 
 
 def test_migrate_import_checks_database_with_same_connection_options(
@@ -1819,7 +1878,7 @@ def test_migrate_import_skips_already_imported_without_force(
     )
 
     assert result.exit_code == 0
-    assert result.output == "Imported 0 file(s).\n"
+    assert result.output == "Running import...\nImported 0 file(s).\n"
     assert calls == 0
 
 
@@ -1923,7 +1982,15 @@ def test_migrate_import_requires_transformed_file(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "has not been transformed. Run transform first." in result.output
+    manifest = _read_manifest(work_dir)
+    file_path = Path(manifest["files"][0]["export_lp_path"])
+    assert result.output == (
+        "Running import...\n"
+        f"Error: File {file_path} has not been transformed. "
+        "Run transform first.\n"
+        f"Error: File {file_path} has not been transformed. "
+        "Run transform first.\n"
+    )
 
 
 def test_migrate_import_records_subprocess_failure(
@@ -1936,7 +2003,7 @@ def test_migrate_import_records_subprocess_failure(
     runner = CliRunner()
     _discover_source_run(runner, backup_dir, work_dir)
     run_dir = _manifest_run_dir(work_dir)
-    _write_exported_lp(work_dir, "weather temp=82\n")
+    file_path = _write_exported_lp(work_dir, "weather temp=82\n")
     _mark_transformed(work_dir)
 
     def fake_run(
@@ -1970,6 +2037,9 @@ def test_migrate_import_records_subprocess_failure(
     )
 
     assert result.exit_code != 0
+    assert result.output.startswith("Running import...\n")
+    assert "Added import headers to" in result.output
+    assert (f"Error: Failed to import {file_path}: boom\n") in result.output
     manifest = _read_manifest(work_dir)
     assert manifest["files"][0]["last_error"] == "boom"
 
@@ -2177,6 +2247,7 @@ def test_migrate_import_defaults_to_all_shards(
 
     assert result.exit_code == 0
     assert result.output == (
+        "Running import...\n"
         f"Added import headers to {file_paths['975']} for "
         "database=lsst.square.metrics, retention=autogen.\n"
         "Imported 2 file(s).\n"
@@ -2204,7 +2275,11 @@ def test_migrate_import_requires_run_dir_manifest(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "No migration-manifest.json found" in result.output
+    assert result.output == (
+        "Running import...\n"
+        f"Error: No migration-manifest.json found in {run_dir}.\n"
+        f"Error: No migration-manifest.json found in {run_dir}.\n"
+    )
 
 
 def test_migrate_import_help_uses_run_dir_only() -> None:

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -108,6 +108,13 @@ def _read_manifest(work_dir: Path) -> dict[str, Any]:
     return json.loads(manifests[0].read_text(encoding="utf-8"))
 
 
+def _manifest_run_dir(work_dir: Path) -> Path:
+    """Return the single run directory containing the manifest."""
+    manifests = list(work_dir.rglob("migration-manifest.json"))
+    assert len(manifests) == 1
+    return manifests[0].parent
+
+
 def _write_exported_lp(work_dir: Path, content: str) -> Path:
     """Write exported line protocol content for the current manifest."""
     manifest = _read_manifest(work_dir)
@@ -140,6 +147,34 @@ def _mark_transformed(work_dir: Path) -> None:
     manifest["status"] = "transformed"
     for record in manifest["files"]:
         record["transformed_at"] = "2026-04-29T00:00:00+00:00"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _mark_exported(work_dir: Path) -> None:
+    """Mark all manifest files as exported for status tests."""
+    manifest_path = next(work_dir.rglob("migration-manifest.json"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["status"] = "exported"
+    for record in manifest["files"]:
+        record["exported_at"] = "2026-04-29T00:00:00+00:00"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _mark_imported(work_dir: Path) -> None:
+    """Mark all manifest files as imported for status tests."""
+    manifest_path = next(work_dir.rglob("migration-manifest.json"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["status"] = "imported"
+    for record in manifest["files"]:
+        record["imported_at"] = "2026-04-29T01:00:00+00:00"
+        record["transformed_at"] = "2026-04-29T00:30:00+00:00"
+        record["exported_at"] = "2026-04-29T00:00:00+00:00"
     manifest_path.write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -1324,6 +1359,76 @@ def test_migrate_transform_reports_tag_to_field_conflicts(
     assert manifest["files"][0]["last_error"] is not None
 
 
+def test_migrate_transform_saves_progress_after_each_file(
+    tmp_path: Path,
+) -> None:
+    """Transform should persist successful file progress before failure."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(
+        "- op: convert-tag-to-field\n  tag: region\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    _write_all_exported_lp(
+        work_dir,
+        {
+            "975": "weather,region=us temp=82\n",
+            "986": 'weather,region=us region="west"\n',
+        },
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    manifest = _read_manifest(work_dir)
+    by_shard = {record["shard_id"]: record for record in manifest["files"]}
+    assert manifest["status"] == "transforming"
+    assert manifest["transform_plan_path"] == str(plan_path)
+    assert manifest["transform_plan_hash"] is not None
+    assert by_shard["975"]["transformed_at"] is not None
+    assert by_shard["975"]["last_error"] is None
+    assert by_shard["986"]["transformed_at"] is None
+    assert by_shard["986"]["last_error"] is not None
+
+
 def test_migrate_transform_defaults_to_all_shards(
     tmp_path: Path,
 ) -> None:
@@ -1707,6 +1812,86 @@ def test_migrate_import_records_subprocess_failure(
     assert manifest["files"][0]["last_error"] == "boom"
 
 
+def test_migrate_import_saves_progress_after_each_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should persist successful file progress before failure."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    _write_all_exported_lp(
+        work_dir,
+        {
+            "975": "weather temp=82\n",
+            "986": "cpu value=1i\n",
+        },
+    )
+    _mark_transformed(work_dir)
+
+    calls = 0
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return subprocess.CompletedProcess(argv, 0, "imported", "")
+        return subprocess.CompletedProcess(argv, 1, "", "boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--work-dir",
+            str(work_dir),
+            "--host",
+            "influxdb.example.org",
+        ],
+    )
+
+    assert result.exit_code != 0
+    manifest = _read_manifest(work_dir)
+    by_shard = {record["shard_id"]: record for record in manifest["files"]}
+    assert manifest["status"] == "importing"
+    assert by_shard["975"]["imported_at"] is not None
+    assert by_shard["975"]["last_error"] is None
+    assert by_shard["986"]["imported_at"] is None
+    assert by_shard["986"]["last_error"] == "boom"
+
+
 def test_migrate_import_defaults_to_all_shards(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1839,3 +2024,294 @@ def test_explicit_shard_runs_remain_isolated_from_all_shards(
         "No discovered files found in the manifest. Run export first."
         in result.output
     )
+
+
+def test_migrate_status_requires_manifest(tmp_path: Path) -> None:
+    """Status should fail when the run directory has no manifest."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["influxdb", "migrate", "status", "--run-dir", str(run_dir)],
+    )
+
+    assert result.exit_code != 0
+    assert "No migration-manifest.json found" in result.output
+
+
+def test_migrate_status_reports_discovered_run(tmp_path: Path) -> None:
+    """Status should report a discovered-only run."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert result.exit_code == 0
+
+    status_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "status",
+            "--run-dir",
+            str(_manifest_run_dir(work_dir)),
+        ],
+    )
+
+    assert status_result.exit_code == 0
+    assert "Manifest status: discovered" in status_result.output
+    assert "Mode: explicit" in status_result.output
+    assert "Exported: 0/1" in status_result.output
+    assert "975    1/1" in status_result.output
+    assert "discovered" in status_result.output
+    assert "Errors:" not in status_result.output
+
+
+def test_migrate_status_reports_exported_run(tmp_path: Path) -> None:
+    """Status should report an exported run."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    _mark_exported(work_dir)
+
+    status_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "status",
+            "--run-dir",
+            str(_manifest_run_dir(work_dir)),
+        ],
+    )
+
+    assert status_result.exit_code == 0
+    assert "Manifest status: exported" in status_result.output
+    assert "Exported: 1/1" in status_result.output
+    assert "Transformed: 0/1" in status_result.output
+
+
+def test_migrate_status_reports_transformed_run(tmp_path: Path) -> None:
+    """Status should report a transformed run."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    _mark_exported(work_dir)
+    _mark_transformed(work_dir)
+
+    status_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "status",
+            "--run-dir",
+            str(_manifest_run_dir(work_dir)),
+        ],
+    )
+
+    assert status_result.exit_code == 0
+    assert "Manifest status: transformed" in status_result.output
+    assert "Transformed: 1/1" in status_result.output
+    assert "Imported: 0/1" in status_result.output
+
+
+def test_migrate_status_reports_imported_run(tmp_path: Path) -> None:
+    """Status should report an imported run."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    _mark_imported(work_dir)
+
+    status_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "status",
+            "--run-dir",
+            str(_manifest_run_dir(work_dir)),
+        ],
+    )
+
+    assert status_result.exit_code == 0
+    assert "Manifest status: imported" in status_result.output
+    assert "Imported: 1/1" in status_result.output
+    assert "Error files: 0" in status_result.output
+
+
+def test_migrate_status_reports_in_progress_and_error_shards(
+    tmp_path: Path,
+) -> None:
+    """Status should report mixed shard progress and errors."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    manifest_path = _manifest_run_dir(work_dir) / "migration-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["status"] = "transformed"
+    by_shard = {record["shard_id"]: record for record in manifest["files"]}
+    by_shard["975"]["exported_at"] = "2026-04-29T00:00:00+00:00"
+    by_shard["975"]["transformed_at"] = "2026-04-29T00:30:00+00:00"
+    by_shard["986"]["exported_at"] = "2026-04-29T00:00:00+00:00"
+    by_shard["986"]["last_error"] = "boom"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    status_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "status",
+            "--run-dir",
+            str(_manifest_run_dir(work_dir)),
+        ],
+    )
+
+    assert status_result.exit_code == 0
+    assert "Mode: all-shards" in status_result.output
+    assert "Error files: 1" in status_result.output
+    assert "975" in status_result.output
+    assert "transformed" in status_result.output
+    assert "986" in status_result.output
+    assert "error" in status_result.output
+    assert "Errors:" in status_result.output
+    assert "File: 000000010-000000001.lp" in status_result.output
+    assert "Error: boom" in status_result.output
+
+
+def test_migrate_status_reports_invalid_manifest_json(tmp_path: Path) -> None:
+    """Status should fail on invalid manifest JSON."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "migration-manifest.json").write_text(
+        "{bad json\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["influxdb", "migrate", "status", "--run-dir", str(run_dir)],
+    )
+
+    assert result.exit_code != 0
+    assert "Failed to parse manifest file" in result.output
+
+
+def test_migrate_status_reports_missing_required_fields(
+    tmp_path: Path,
+) -> None:
+    """Status should fail on incomplete manifest data."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "migration-manifest.json").write_text(
+        json.dumps({"run_id": "abc"}) + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["influxdb", "migrate", "status", "--run-dir", str(run_dir)],
+    )
+
+    assert result.exit_code != 0
+    assert "missing required fields" in result.output

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -233,6 +233,7 @@ def test_migrate_export_updates_manifest_and_writes_lp(
         assert check is False
         assert text is True
         assert argv[0] == "influx_inspect"
+        assert "-lponly" in argv
         out_path = Path(argv[argv.index("-out") + 1])
         tsm_path = Path(argv[argv.index("-tsmfile") + 1])
         assert tsm_path.exists()

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -184,7 +184,7 @@ def _mark_imported(work_dir: Path) -> None:
 def _discover_source_run(
     runner: CliRunner,
     backup_dir: Path,
-    work_dir: Path,
+    run_dir: Path,
 ) -> None:
     """Create a manifest using the source database and retention."""
     result = runner.invoke(
@@ -201,8 +201,8 @@ def _discover_source_run(
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
     assert result.exit_code == 0
@@ -211,7 +211,7 @@ def _discover_source_run(
 def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
     """Discover should create a manifest from shard archives."""
     backup_dir = _create_backup_tree(tmp_path)
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -228,26 +228,52 @@ def test_migrate_discover_creates_manifest(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
     assert result.exit_code == 0
     assert result.output == "Discovered 1 TSM file(s) in 1 shard(s).\n"
 
-    manifest = _read_manifest(work_dir)
+    manifest = _read_manifest(run_dir)
     assert manifest["database"] == "lsst.square.metrics"
     assert manifest["retention"] == "autogen"
     assert manifest["shards"] == ["975"]
     assert manifest["status"] == "discovered"
     assert len(manifest["files"]) == 1
-    assert _read_manifest(
-        work_dir
-    )  # manifest exists under the shortened run dir
-    run_dir = next(work_dir.iterdir())
-    assert run_dir.name.startswith("lsst.square.metrics--autogen--")
-    assert run_dir.name.count("--") == 2
+    assert manifest["run_id"]
+    assert (run_dir / "migration-manifest.json").exists()
+
+
+def test_migrate_discover_rejects_existing_run_dir(tmp_path: Path) -> None:
+    """Discover should fail when the requested run directory exists."""
+    backup_dir = _create_backup_tree(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--run-dir",
+            str(run_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert f"Run directory {run_dir} already exists." in result.output
 
 
 def test_influxdb_help_shows_line_protocol_and_migrate_groups() -> None:
@@ -264,7 +290,7 @@ def test_influxdb_help_shows_line_protocol_and_migrate_groups() -> None:
 def test_migrate_discover_rejects_missing_shard(tmp_path: Path) -> None:
     """Discover should fail when a requested shard is not present."""
     backup_dir = _create_backup_tree(tmp_path)
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -281,8 +307,8 @@ def test_migrate_discover_rejects_missing_shard(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "998",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
@@ -295,7 +321,7 @@ def test_migrate_discover_all_shards_uses_backup_manifest(
 ) -> None:
     """Discover all-shards should use the backup manifest as its source."""
     backup_dir = _create_backup_tree(tmp_path)
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -311,14 +337,14 @@ def test_migrate_discover_all_shards_uses_backup_manifest(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
     assert result.exit_code == 0
     assert result.output == "Discovered 2 TSM file(s) in 2 shard(s).\n"
-    manifest = _read_manifest(work_dir)
+    manifest = _read_manifest(run_dir)
     assert manifest["all_shards"] is True
     assert manifest["shards"] == ["975", "986"]
     assert {record["shard_id"] for record in manifest["files"]} == {
@@ -332,7 +358,7 @@ def test_migrate_discover_all_shards_requires_backup_manifest(
 ) -> None:
     """Discover all-shards should fail without a backup manifest."""
     backup_dir = _create_backup_tree_without_manifest(tmp_path)
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -348,8 +374,8 @@ def test_migrate_discover_all_shards_requires_backup_manifest(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
@@ -364,7 +390,7 @@ def test_migrate_discover_all_shards_rejects_multiple_manifests(
     backup_dir = _create_backup_tree(tmp_path)
     extra_manifest = backup_dir / "extra.manifest"
     extra_manifest.write_text('{"files": []}\n', encoding="utf-8")
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -380,8 +406,8 @@ def test_migrate_discover_all_shards_rejects_multiple_manifests(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
@@ -394,7 +420,7 @@ def test_migrate_discover_all_shards_rejects_no_matching_manifest_entries(
 ) -> None:
     """Discover all-shards should fail when the manifest has no matches."""
     backup_dir = _create_backup_tree(tmp_path)
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -410,8 +436,8 @@ def test_migrate_discover_all_shards_rejects_no_matching_manifest_entries(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
@@ -425,7 +451,7 @@ def test_migrate_discover_all_shards_rejects_missing_archive(
     """Discover all-shards should fail when a manifest archive is missing."""
     backup_dir = _create_backup_tree(tmp_path)
     (backup_dir / "20260424T050008Z.s986.tar.gz").unlink()
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -441,8 +467,8 @@ def test_migrate_discover_all_shards_rejects_missing_archive(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
@@ -467,7 +493,7 @@ def test_migrate_discover_all_shards_rejects_archive_without_matching_tsm(
             wrong_tsm_path,
             arcname="wrong.metrics/autogen/986/000000010-000000001.tsm",
         )
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -483,8 +509,8 @@ def test_migrate_discover_all_shards_rejects_archive_without_matching_tsm(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
@@ -492,28 +518,12 @@ def test_migrate_discover_all_shards_rejects_archive_without_matching_tsm(
     assert "does not contain matching TSM files" in result.output
 
 
-@pytest.mark.parametrize(
-    ("command", "extra_args"),
-    [
-        ("discover", []),
-        ("export", []),
-        ("transform", ["--plan", "PLACEHOLDER"]),
-        ("import", ["--host", "influxdb.example.org"]),
-    ],
-)
-def test_migrate_commands_reject_mixed_shard_selection(
-    command: str,
-    extra_args: list[str],
+def test_migrate_discover_rejects_mixed_shard_selection(
     tmp_path: Path,
 ) -> None:
-    """Commands should reject mixing --shard with --all-shards."""
+    """Discover should reject mixing --shard with --all-shards."""
     backup_dir = _create_backup_tree(tmp_path)
-    work_dir = tmp_path / "work"
-    plan_path = tmp_path / "plan.yaml"
-    plan_path.write_text("- op: drop-tag\n  tag: region\n", encoding="utf-8")
-    resolved_extra_args = [
-        str(plan_path) if arg == "PLACEHOLDER" else arg for arg in extra_args
-    ]
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -521,7 +531,7 @@ def test_migrate_commands_reject_mixed_shard_selection(
         [
             "influxdb",
             "migrate",
-            command,
+            "discover",
             "--backup-dir",
             str(backup_dir),
             "--database",
@@ -531,14 +541,29 @@ def test_migrate_commands_reject_mixed_shard_selection(
             "--shard",
             "975",
             "--all-shards",
-            "--work-dir",
-            str(work_dir),
-            *resolved_extra_args,
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
     assert result.exit_code != 0
     assert "Use either --shard or --all-shards, not both." in result.output
+
+
+def test_migrate_discover_help_uses_run_dir_only() -> None:
+    """Discover help should expose run-dir instead of work-dir."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["influxdb", "migrate", "discover", "--help"],
+    )
+
+    assert result.exit_code == 0
+    assert "--run-dir" in result.output
+    assert "--backup-dir" in result.output
+    assert "--database" in result.output
+    assert "--retention" in result.output
+    assert "--work-dir" not in result.output
 
 
 def test_migrate_discover_real_sample_data(tmp_path: Path) -> None:
@@ -548,7 +573,7 @@ def test_migrate_discover_real_sample_data(tmp_path: Path) -> None:
         / "data"
         / "sasquatch-influxdb-oss-full-20260421T050014Z"
     )
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -565,15 +590,15 @@ def test_migrate_discover_real_sample_data(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
     assert result.exit_code == 0
     assert result.output == "Discovered 1 TSM file(s) in 1 shard(s).\n"
 
-    manifest = _read_manifest(work_dir)
+    manifest = _read_manifest(run_dir)
     assert manifest["shards"] == ["975"]
     member_paths = [
         record["archive_member_path"] for record in manifest["files"]
@@ -589,7 +614,7 @@ def test_migrate_export_updates_manifest_and_writes_lp(
 ) -> None:
     """Export should stage TSM files and write LP output."""
     backup_dir = _create_backup_tree(tmp_path)
-    work_dir = tmp_path / "work"
+    run_dir = tmp_path / "run"
 
     def fake_run(
         argv: list[str],
@@ -629,8 +654,8 @@ def test_migrate_export_updates_manifest_and_writes_lp(
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
     assert discover_result.exit_code == 0
@@ -641,23 +666,15 @@ def test_migrate_export_updates_manifest_and_writes_lp(
             "influxdb",
             "migrate",
             "export",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
     assert export_result.exit_code == 0
     assert export_result.output == "Exported 1 file(s).\n"
 
-    manifest = _read_manifest(work_dir)
+    manifest = _read_manifest(run_dir)
     assert manifest["status"] == "exported"
     file_record = manifest["files"][0]
     assert file_record["exported_at"] is not None
@@ -669,26 +686,10 @@ def test_migrate_export_updates_manifest_and_writes_lp(
     )
 
 
-def test_migrate_export_discovers_when_manifest_is_empty(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Export should perform discovery first when no manifest exists yet."""
-    backup_dir = _create_backup_tree(tmp_path)
-    work_dir = tmp_path / "work"
+def test_migrate_export_requires_existing_run_dir(tmp_path: Path) -> None:
+    """Export should fail when the run directory does not exist."""
+    run_dir = tmp_path / "missing-run"
 
-    def fake_run(
-        argv: list[str],
-        *,
-        capture_output: bool,
-        check: bool,
-        text: bool,
-    ) -> subprocess.CompletedProcess[str]:
-        out_path = Path(argv[argv.index("-out") + 1])
-        out_path.write_text("cpu value=1i\n", encoding="utf-8")
-        return subprocess.CompletedProcess(argv, 0, "exported", "")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
     runner = CliRunner()
     result = runner.invoke(
         main,
@@ -696,111 +697,94 @@ def test_migrate_export_discovers_when_manifest_is_empty(
             "influxdb",
             "migrate",
             "export",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
-        ],
-    )
-
-    assert result.exit_code == 0
-    manifest = _read_manifest(work_dir)
-    assert manifest["status"] == "exported"
-    assert len(manifest["files"]) == 1
-
-
-def test_migrate_export_all_shards_bootstraps_manifest_discovery(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Export all-shards should discover through the backup manifest."""
-    backup_dir = _create_backup_tree(tmp_path)
-    work_dir = tmp_path / "work"
-
-    def fake_run(
-        argv: list[str],
-        *,
-        capture_output: bool,
-        check: bool,
-        text: bool,
-    ) -> subprocess.CompletedProcess[str]:
-        out_path = Path(argv[argv.index("-out") + 1])
-        out_path.write_text("cpu value=1i\n", encoding="utf-8")
-        return subprocess.CompletedProcess(argv, 0, "exported", "")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    runner = CliRunner()
-    result = runner.invoke(
-        main,
-        [
-            "influxdb",
-            "migrate",
-            "export",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--all-shards",
-            "--work-dir",
-            str(work_dir),
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert result.output == "Exported 2 file(s).\n"
-    manifest = _read_manifest(work_dir)
-    assert manifest["all_shards"] is True
-    assert manifest["shards"] == ["975", "986"]
-    assert len(manifest["files"]) == 2
-
-
-def test_migrate_export_all_shards_requires_manifest_when_bootstrapping(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Export all-shards should fail without a backup manifest."""
-    backup_dir = _create_backup_tree_without_manifest(tmp_path)
-    work_dir = tmp_path / "work"
-
-    def fake_run(
-        argv: list[str],
-        *,
-        capture_output: bool,
-        check: bool,
-        text: bool,
-    ) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(argv, 0, "exported", "")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    runner = CliRunner()
-    result = runner.invoke(
-        main,
-        [
-            "influxdb",
-            "migrate",
-            "export",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--all-shards",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
         ],
     )
 
     assert result.exit_code != 0
-    assert "No backup manifest file found" in result.output
+    assert "No migration-manifest.json found" in result.output
+
+
+def test_migrate_export_requires_manifest(tmp_path: Path) -> None:
+    """Export should fail when the run directory has no manifest."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "export",
+            "--run-dir",
+            str(run_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "No migration-manifest.json found" in result.output
+
+
+def test_migrate_export_requires_discovered_files(tmp_path: Path) -> None:
+    """Export should fail when the manifest has no discovered files."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    manifest = {
+        "all_shards": False,
+        "backup_dir": str(tmp_path / "backup"),
+        "backup_name": "backup",
+        "created_at": "2026-04-29T00:00:00+00:00",
+        "database": "lsst.square.metrics",
+        "files": [],
+        "retention": "autogen",
+        "run_id": "abc123",
+        "shards": ["975"],
+        "status": "initialized",
+        "updated_at": "2026-04-29T00:00:00+00:00",
+    }
+    (run_dir / "migration-manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "export",
+            "--run-dir",
+            str(run_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "No discovered files found in the manifest. Run discover first."
+        in result.output
+    )
+
+
+def test_migrate_export_help_uses_run_dir_only() -> None:
+    """Export help should expose the run-dir interface only."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["influxdb", "migrate", "export", "--help"],
+    )
+
+    assert result.exit_code == 0
+    assert "--run-dir" in result.output
+    assert "--force" in result.output
+    assert "--backup-dir" not in result.output
+    assert "--database" not in result.output
+    assert "--retention" not in result.output
+    assert "--shard" not in result.output
+    assert "--all-shards" not in result.output
+    assert "--work-dir" not in result.output
 
 
 def test_migrate_transform_updates_manifest_and_rewrites_lp(
@@ -830,11 +814,12 @@ def test_migrate_transform_updates_manifest_and_rewrites_lp(
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
     assert discover_result.exit_code == 0
+    run_dir = _manifest_run_dir(work_dir)
 
     export_lp_path = _write_exported_lp(
         work_dir,
@@ -847,16 +832,8 @@ def test_migrate_transform_updates_manifest_and_rewrites_lp(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(plan_path),
         ],
@@ -900,10 +877,11 @@ def test_migrate_transform_skips_already_transformed_files(
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
+    run_dir = _manifest_run_dir(work_dir)
     export_lp_path = _write_exported_lp(
         work_dir,
         "weather,region=us temp=82\n",
@@ -915,16 +893,8 @@ def test_migrate_transform_skips_already_transformed_files(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(plan_path),
         ],
@@ -938,16 +908,8 @@ def test_migrate_transform_skips_already_transformed_files(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(plan_path),
         ],
@@ -988,10 +950,11 @@ def test_migrate_transform_reapplies_with_force(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
+    run_dir = _manifest_run_dir(work_dir)
     export_lp_path = _write_exported_lp(
         work_dir,
         "weather,region=us temp=82\n",
@@ -1003,16 +966,8 @@ def test_migrate_transform_reapplies_with_force(tmp_path: Path) -> None:
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(first_plan),
         ],
@@ -1025,16 +980,8 @@ def test_migrate_transform_reapplies_with_force(tmp_path: Path) -> None:
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(second_plan),
             "--force",
@@ -1069,10 +1016,11 @@ def test_migrate_transform_rejects_invalid_plan_extension(
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
+    run_dir = _manifest_run_dir(work_dir)
     _write_exported_lp(work_dir, "weather,region=us temp=82\n")
 
     result = runner.invoke(
@@ -1081,16 +1029,8 @@ def test_migrate_transform_rejects_invalid_plan_extension(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(plan_path),
         ],
@@ -1127,10 +1067,11 @@ def test_migrate_transform_rejects_unknown_operation(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
+    run_dir = _manifest_run_dir(work_dir)
     _write_exported_lp(work_dir, "weather,region=us temp=82\n")
 
     result = runner.invoke(
@@ -1139,16 +1080,8 @@ def test_migrate_transform_rejects_unknown_operation(tmp_path: Path) -> None:
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(plan_path),
         ],
@@ -1183,10 +1116,11 @@ def test_migrate_transform_requires_exported_file(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
+    run_dir = _manifest_run_dir(work_dir)
 
     result = runner.invoke(
         main,
@@ -1194,16 +1128,8 @@ def test_migrate_transform_requires_exported_file(tmp_path: Path) -> None:
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(plan_path),
         ],
@@ -1245,10 +1171,11 @@ def test_migrate_transform_rejects_changed_plan_without_force(
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
+    run_dir = _manifest_run_dir(work_dir)
     _write_exported_lp(work_dir, "weather,region=us temp=82\n")
 
     first_result = runner.invoke(
@@ -1257,16 +1184,8 @@ def test_migrate_transform_rejects_changed_plan_without_force(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(first_plan),
         ],
@@ -1279,16 +1198,8 @@ def test_migrate_transform_rejects_changed_plan_without_force(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(second_plan),
         ],
@@ -1327,10 +1238,11 @@ def test_migrate_transform_reports_tag_to_field_conflicts(
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
+    run_dir = _manifest_run_dir(work_dir)
     _write_exported_lp(work_dir, 'weather,region=us region="west"\n')
 
     result = runner.invoke(
@@ -1339,16 +1251,8 @@ def test_migrate_transform_reports_tag_to_field_conflicts(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(plan_path),
         ],
@@ -1385,11 +1289,12 @@ def test_migrate_transform_saves_progress_after_each_file(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
     assert discover_result.exit_code == 0
+    run_dir = _manifest_run_dir(work_dir)
     _write_all_exported_lp(
         work_dir,
         {
@@ -1404,14 +1309,8 @@ def test_migrate_transform_saves_progress_after_each_file(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(plan_path),
         ],
@@ -1452,11 +1351,12 @@ def test_migrate_transform_defaults_to_all_shards(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
     assert discover_result.exit_code == 0
+    run_dir = _manifest_run_dir(work_dir)
     file_paths = _write_all_exported_lp(
         work_dir,
         {
@@ -1471,14 +1371,8 @@ def test_migrate_transform_defaults_to_all_shards(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--plan",
             str(plan_path),
         ],
@@ -1490,6 +1384,50 @@ def test_migrate_transform_defaults_to_all_shards(
     assert file_paths["986"].read_text(encoding="utf-8") == "cpu value=1i\n"
 
 
+def test_migrate_transform_requires_run_dir_manifest(tmp_path: Path) -> None:
+    """Transform should fail when run-dir has no manifest."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text("- op: drop-tag\n  tag: region\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--run-dir",
+            str(run_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "No migration-manifest.json found" in result.output
+
+
+def test_migrate_transform_help_uses_run_dir_only() -> None:
+    """Transform help should expose the run-dir interface only."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["influxdb", "migrate", "transform", "--help"],
+    )
+
+    assert result.exit_code == 0
+    assert "--run-dir" in result.output
+    assert "--plan" in result.output
+    assert "--backup-dir" not in result.output
+    assert "--database" not in result.output
+    assert "--retention" not in result.output
+    assert "--shard" not in result.output
+    assert "--all-shards" not in result.output
+    assert "--work-dir" not in result.output
+
+
 def test_migrate_import_updates_manifest_and_rewrites_headers(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1499,6 +1437,7 @@ def test_migrate_import_updates_manifest_and_rewrites_headers(
     work_dir = tmp_path / "work"
     runner = CliRunner()
     _discover_source_run(runner, backup_dir, work_dir)
+    run_dir = _manifest_run_dir(work_dir)
     file_path = _write_exported_lp(
         work_dir,
         "# DML\n"
@@ -1527,16 +1466,8 @@ def test_migrate_import_updates_manifest_and_rewrites_headers(
             "influxdb",
             "migrate",
             "import",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--host",
             "influxdb.example.org",
             "--target-database",
@@ -1567,6 +1498,7 @@ def test_migrate_import_adds_missing_headers_and_reports_it(
     work_dir = tmp_path / "work"
     runner = CliRunner()
     _discover_source_run(runner, backup_dir, work_dir)
+    run_dir = _manifest_run_dir(work_dir)
     file_path = _write_exported_lp(work_dir, "weather temp=82\n")
     _mark_transformed(work_dir)
 
@@ -1586,16 +1518,8 @@ def test_migrate_import_adds_missing_headers_and_reports_it(
             "influxdb",
             "migrate",
             "import",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--host",
             "influxdb.example.org",
             "--target-database",
@@ -1624,6 +1548,7 @@ def test_migrate_import_is_quiet_when_headers_already_match(
     work_dir = tmp_path / "work"
     runner = CliRunner()
     _discover_source_run(runner, backup_dir, work_dir)
+    run_dir = _manifest_run_dir(work_dir)
     _write_exported_lp(
         work_dir,
         "# DML\n"
@@ -1649,16 +1574,8 @@ def test_migrate_import_is_quiet_when_headers_already_match(
             "influxdb",
             "migrate",
             "import",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--host",
             "influxdb.example.org",
             "--target-database",
@@ -1681,6 +1598,7 @@ def test_migrate_import_skips_already_imported_without_force(
     work_dir = tmp_path / "work"
     runner = CliRunner()
     _discover_source_run(runner, backup_dir, work_dir)
+    run_dir = _manifest_run_dir(work_dir)
     _write_exported_lp(work_dir, "weather temp=82\n")
     _mark_transformed(work_dir)
     manifest_path = next(work_dir.rglob("migration-manifest.json"))
@@ -1711,16 +1629,8 @@ def test_migrate_import_skips_already_imported_without_force(
             "influxdb",
             "migrate",
             "import",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--host",
             "influxdb.example.org",
         ],
@@ -1737,6 +1647,7 @@ def test_migrate_import_requires_transformed_file(tmp_path: Path) -> None:
     work_dir = tmp_path / "work"
     runner = CliRunner()
     _discover_source_run(runner, backup_dir, work_dir)
+    run_dir = _manifest_run_dir(work_dir)
     _write_exported_lp(work_dir, "weather temp=82\n")
 
     result = runner.invoke(
@@ -1745,16 +1656,8 @@ def test_migrate_import_requires_transformed_file(tmp_path: Path) -> None:
             "influxdb",
             "migrate",
             "import",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--host",
             "influxdb.example.org",
         ],
@@ -1773,6 +1676,7 @@ def test_migrate_import_records_subprocess_failure(
     work_dir = tmp_path / "work"
     runner = CliRunner()
     _discover_source_run(runner, backup_dir, work_dir)
+    run_dir = _manifest_run_dir(work_dir)
     _write_exported_lp(work_dir, "weather temp=82\n")
     _mark_transformed(work_dir)
 
@@ -1792,16 +1696,8 @@ def test_migrate_import_records_subprocess_failure(
             "influxdb",
             "migrate",
             "import",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--shard",
-            "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--host",
             "influxdb.example.org",
         ],
@@ -1833,11 +1729,12 @@ def test_migrate_import_saves_progress_after_each_file(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
     assert discover_result.exit_code == 0
+    run_dir = _manifest_run_dir(work_dir)
     _write_all_exported_lp(
         work_dir,
         {
@@ -1869,14 +1766,8 @@ def test_migrate_import_saves_progress_after_each_file(
             "influxdb",
             "migrate",
             "import",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--host",
             "influxdb.example.org",
         ],
@@ -1913,11 +1804,12 @@ def test_migrate_import_defaults_to_all_shards(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
     assert discover_result.exit_code == 0
+    run_dir = _manifest_run_dir(work_dir)
     file_paths = _write_all_exported_lp(
         work_dir,
         {
@@ -1947,14 +1839,8 @@ def test_migrate_import_defaults_to_all_shards(
             "influxdb",
             "migrate",
             "import",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(run_dir),
             "--host",
             "influxdb.example.org",
         ],
@@ -1969,12 +1855,55 @@ def test_migrate_import_defaults_to_all_shards(
     assert len(calls) == 2
 
 
+def test_migrate_import_requires_run_dir_manifest(tmp_path: Path) -> None:
+    """Import should fail when run-dir has no manifest."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--run-dir",
+            str(run_dir),
+            "--host",
+            "influxdb.example.org",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "No migration-manifest.json found" in result.output
+
+
+def test_migrate_import_help_uses_run_dir_only() -> None:
+    """Import help should expose the run-dir interface only."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["influxdb", "migrate", "import", "--help"],
+    )
+
+    assert result.exit_code == 0
+    assert "--run-dir" in result.output
+    assert "--host" in result.output
+    assert "--backup-dir" not in result.output
+    assert "--database" not in result.output
+    assert "--retention" not in result.output
+    assert "--shard" not in result.output
+    assert "--all-shards" not in result.output
+    assert "--work-dir" not in result.output
+
+
 def test_explicit_shard_runs_remain_isolated_from_all_shards(
     tmp_path: Path,
 ) -> None:
-    """Explicit shard runs should stay isolated from implicit all-shards."""
+    """Explicit and all-shards run directories should stay isolated."""
     backup_dir = _create_backup_tree(tmp_path)
-    work_dir = tmp_path / "work"
+    explicit_run_dir = tmp_path / "explicit-run"
+    all_shards_run_dir = tmp_path / "all-shards-run"
     plan_path = tmp_path / "plan.yaml"
     plan_path.write_text("- op: drop-tag\n  tag: region\n", encoding="utf-8")
 
@@ -1993,12 +1922,57 @@ def test_explicit_shard_runs_remain_isolated_from_all_shards(
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(explicit_run_dir),
         ],
     )
     assert discover_result.exit_code == 0
-    _write_exported_lp(work_dir, "weather,region=us temp=82\n")
+    explicit_manifest = json.loads(
+        (explicit_run_dir / "migration-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    explicit_lp_path = Path(explicit_manifest["files"][0]["export_lp_path"])
+    explicit_lp_path.parent.mkdir(parents=True, exist_ok=True)
+    explicit_lp_path.write_text(
+        "weather,region=us temp=82\n",
+        encoding="utf-8",
+    )
+
+    all_shards_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--run-dir",
+            str(all_shards_run_dir),
+        ],
+    )
+    assert all_shards_result.exit_code == 0
+    all_shards_manifest = json.loads(
+        (all_shards_run_dir / "migration-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    all_shards_lp_paths = {
+        record["shard_id"]: Path(record["export_lp_path"])
+        for record in all_shards_manifest["files"]
+    }
+    for shard_id, content in {
+        "975": "weather,region=us temp=82\n",
+        "986": "cpu,region=us value=1i\n",
+    }.items():
+        lp_path = all_shards_lp_paths[shard_id]
+        lp_path.parent.mkdir(parents=True, exist_ok=True)
+        lp_path.write_text(content, encoding="utf-8")
 
     result = runner.invoke(
         main,
@@ -2006,23 +1980,22 @@ def test_explicit_shard_runs_remain_isolated_from_all_shards(
             "influxdb",
             "migrate",
             "transform",
-            "--backup-dir",
-            str(backup_dir),
-            "--database",
-            "lsst.square.metrics",
-            "--retention",
-            "autogen",
-            "--work-dir",
-            str(work_dir),
+            "--run-dir",
+            str(explicit_run_dir),
             "--plan",
             str(plan_path),
         ],
     )
 
-    assert result.exit_code != 0
+    assert result.exit_code == 0
+    assert explicit_lp_path.read_text(encoding="utf-8") == "weather temp=82\n"
     assert (
-        "No discovered files found in the manifest. Run export first."
-        in result.output
+        all_shards_lp_paths["975"].read_text(encoding="utf-8")
+        == "weather,region=us temp=82\n"
+    )
+    assert (
+        all_shards_lp_paths["986"].read_text(encoding="utf-8")
+        == "cpu,region=us value=1i\n"
     )
 
 
@@ -2060,7 +2033,7 @@ def test_migrate_status_reports_discovered_run(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
@@ -2105,7 +2078,7 @@ def test_migrate_status_reports_exported_run(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
@@ -2148,7 +2121,7 @@ def test_migrate_status_reports_transformed_run(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
@@ -2192,7 +2165,7 @@ def test_migrate_status_reports_imported_run(tmp_path: Path) -> None:
             "autogen",
             "--shard",
             "975",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )
@@ -2236,7 +2209,7 @@ def test_migrate_status_reports_in_progress_and_error_shards(
             "--retention",
             "autogen",
             "--all-shards",
-            "--work-dir",
+            "--run-dir",
             str(work_dir),
         ],
     )

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -18,20 +18,86 @@ def _create_backup_tree(tmp_path: Path) -> Path:
     """Create a synthetic backup directory with shard archives."""
     backup_dir = tmp_path / "sasquatch-influxdb-oss-full-20260424T050007Z"
     backup_dir.mkdir()
-
-    archive_path = backup_dir / "20260424T050008Z.s975.tar.gz"
     source_dir = tmp_path / "source"
-    shard_dir = source_dir / "lsst.square.metrics" / "autogen" / "975"
-    shard_dir.mkdir(parents=True)
-    tsm_path = shard_dir / "000000008-000000002.tsm"
-    tsm_path.write_text("placeholder", encoding="utf-8")
+    matching_shards = {
+        "975": "000000008-000000002.tsm",
+        "986": "000000010-000000001.tsm",
+    }
+    for shard_id, file_name in matching_shards.items():
+        archive_path = backup_dir / f"20260424T050008Z.s{shard_id}.tar.gz"
+        shard_dir = source_dir / "lsst.square.metrics" / "autogen" / shard_id
+        shard_dir.mkdir(parents=True, exist_ok=True)
+        tsm_path = shard_dir / file_name
+        tsm_path.write_text("placeholder", encoding="utf-8")
+        with tarfile.open(archive_path, "w:gz") as archive:
+            archive.add(
+                tsm_path,
+                arcname=(
+                    f"lsst.square.metrics/autogen/{shard_id}/{file_name}"
+                ),
+            )
 
-    with tarfile.open(archive_path, "w:gz") as archive:
+    other_archive = backup_dir / "20260424T050008Z.s999.tar.gz"
+    other_shard_dir = source_dir / "other.metrics" / "autogen" / "999"
+    other_shard_dir.mkdir(parents=True, exist_ok=True)
+    other_tsm_path = other_shard_dir / "000000001-000000001.tsm"
+    other_tsm_path.write_text("placeholder", encoding="utf-8")
+    with tarfile.open(other_archive, "w:gz") as archive:
         archive.add(
-            tsm_path,
-            arcname="lsst.square.metrics/autogen/975/000000008-000000002.tsm",
+            other_tsm_path,
+            arcname="other.metrics/autogen/999/000000001-000000001.tsm",
         )
 
+    manifest_path = backup_dir / "20260424T050007Z.manifest"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "meta": {
+                    "fileName": "20260424T050007Z.meta",
+                    "size": 12111,
+                },
+                "limited": False,
+                "files": [
+                    {
+                        "database": "lsst.square.metrics",
+                        "policy": "autogen",
+                        "shardID": 975,
+                        "fileName": "20260424T050008Z.s975.tar.gz",
+                        "size": 1024,
+                        "lastModified": 0,
+                    },
+                    {
+                        "database": "lsst.square.metrics",
+                        "policy": "autogen",
+                        "shardID": 986,
+                        "fileName": "20260424T050008Z.s986.tar.gz",
+                        "size": 1024,
+                        "lastModified": 0,
+                    },
+                    {
+                        "database": "other.metrics",
+                        "policy": "autogen",
+                        "shardID": 999,
+                        "fileName": "20260424T050008Z.s999.tar.gz",
+                        "size": 1024,
+                        "lastModified": 0,
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return backup_dir
+
+
+def _create_backup_tree_without_manifest(tmp_path: Path) -> Path:
+    """Create a synthetic backup directory without a backup manifest."""
+    backup_dir = _create_backup_tree(tmp_path)
+    for manifest_path in backup_dir.glob("*.manifest"):
+        manifest_path.unlink()
     return backup_dir
 
 
@@ -51,12 +117,29 @@ def _write_exported_lp(work_dir: Path, content: str) -> Path:
     return export_lp_path
 
 
+def _write_all_exported_lp(
+    work_dir: Path,
+    content_by_shard: dict[str, str],
+) -> dict[str, Path]:
+    """Write exported line protocol content for all manifest files."""
+    manifest = _read_manifest(work_dir)
+    written: dict[str, Path] = {}
+    for record in manifest["files"]:
+        shard_id = record["shard_id"]
+        export_lp_path = Path(record["export_lp_path"])
+        export_lp_path.parent.mkdir(parents=True, exist_ok=True)
+        export_lp_path.write_text(content_by_shard[shard_id], encoding="utf-8")
+        written[shard_id] = export_lp_path
+    return written
+
+
 def _mark_transformed(work_dir: Path) -> None:
     """Mark the manifest file as transformed for import tests."""
     manifest_path = next(work_dir.rglob("migration-manifest.json"))
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     manifest["status"] = "transformed"
-    manifest["files"][0]["transformed_at"] = "2026-04-29T00:00:00+00:00"
+    for record in manifest["files"]:
+        record["transformed_at"] = "2026-04-29T00:00:00+00:00"
     manifest_path.write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -170,6 +253,257 @@ def test_migrate_discover_rejects_missing_shard(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "No TSM files found for shard '998'" in result.output
+
+
+def test_migrate_discover_all_shards_uses_backup_manifest(
+    tmp_path: Path,
+) -> None:
+    """Discover all-shards should use the backup manifest as its source."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Discovered 2 TSM file(s) in 2 shard(s).\n"
+    manifest = _read_manifest(work_dir)
+    assert manifest["all_shards"] is True
+    assert manifest["shards"] == ["975", "986"]
+    assert {record["shard_id"] for record in manifest["files"]} == {
+        "975",
+        "986",
+    }
+
+
+def test_migrate_discover_all_shards_requires_backup_manifest(
+    tmp_path: Path,
+) -> None:
+    """Discover all-shards should fail without a backup manifest."""
+    backup_dir = _create_backup_tree_without_manifest(tmp_path)
+    work_dir = tmp_path / "work"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "No backup manifest file found" in result.output
+
+
+def test_migrate_discover_all_shards_rejects_multiple_manifests(
+    tmp_path: Path,
+) -> None:
+    """Discover all-shards should fail when multiple backup manifests exist."""
+    backup_dir = _create_backup_tree(tmp_path)
+    extra_manifest = backup_dir / "extra.manifest"
+    extra_manifest.write_text('{"files": []}\n', encoding="utf-8")
+    work_dir = tmp_path / "work"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Multiple backup manifest files found" in result.output
+
+
+def test_migrate_discover_all_shards_rejects_no_matching_manifest_entries(
+    tmp_path: Path,
+) -> None:
+    """Discover all-shards should fail when the manifest has no matches."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "missing.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "No shard entries found in the backup manifest" in result.output
+
+
+def test_migrate_discover_all_shards_rejects_missing_archive(
+    tmp_path: Path,
+) -> None:
+    """Discover all-shards should fail when a manifest archive is missing."""
+    backup_dir = _create_backup_tree(tmp_path)
+    (backup_dir / "20260424T050008Z.s986.tar.gz").unlink()
+    work_dir = tmp_path / "work"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Backup shard archive" in result.output
+    assert "is missing." in result.output
+
+
+def test_migrate_discover_all_shards_rejects_archive_without_matching_tsm(
+    tmp_path: Path,
+) -> None:
+    """Discover all-shards should fail when a shard has no matching TSM."""
+    backup_dir = _create_backup_tree(tmp_path)
+    broken_archive = backup_dir / "20260424T050008Z.s986.tar.gz"
+    source_dir = tmp_path / "broken"
+    wrong_dir = source_dir / "wrong.metrics" / "autogen" / "986"
+    wrong_dir.mkdir(parents=True)
+    wrong_tsm_path = wrong_dir / "000000010-000000001.tsm"
+    wrong_tsm_path.write_text("placeholder", encoding="utf-8")
+    with tarfile.open(broken_archive, "w:gz") as archive:
+        archive.add(
+            wrong_tsm_path,
+            arcname="wrong.metrics/autogen/986/000000010-000000001.tsm",
+        )
+    work_dir = tmp_path / "work"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "does not contain matching TSM files" in result.output
+
+
+@pytest.mark.parametrize(
+    ("command", "extra_args"),
+    [
+        ("discover", []),
+        ("export", []),
+        ("transform", ["--plan", "PLACEHOLDER"]),
+        ("import", ["--host", "influxdb.example.org"]),
+    ],
+)
+def test_migrate_commands_reject_mixed_shard_selection(
+    command: str,
+    extra_args: list[str],
+    tmp_path: Path,
+) -> None:
+    """Commands should reject mixing --shard with --all-shards."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text("- op: drop-tag\n  tag: region\n", encoding="utf-8")
+    resolved_extra_args = [
+        str(plan_path) if arg == "PLACEHOLDER" else arg for arg in extra_args
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            command,
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+            *resolved_extra_args,
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Use either --shard or --all-shards, not both." in result.output
 
 
 def test_migrate_discover_real_sample_data(tmp_path: Path) -> None:
@@ -344,6 +678,94 @@ def test_migrate_export_discovers_when_manifest_is_empty(
     manifest = _read_manifest(work_dir)
     assert manifest["status"] == "exported"
     assert len(manifest["files"]) == 1
+
+
+def test_migrate_export_all_shards_bootstraps_manifest_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Export all-shards should discover through the backup manifest."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        out_path = Path(argv[argv.index("-out") + 1])
+        out_path.write_text("cpu value=1i\n", encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, "exported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "export",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Exported 2 file(s).\n"
+    manifest = _read_manifest(work_dir)
+    assert manifest["all_shards"] is True
+    assert manifest["shards"] == ["975", "986"]
+    assert len(manifest["files"]) == 2
+
+
+def test_migrate_export_all_shards_requires_manifest_when_bootstrapping(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Export all-shards should fail without a backup manifest."""
+    backup_dir = _create_backup_tree_without_manifest(tmp_path)
+    work_dir = tmp_path / "work"
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 0, "exported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "export",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "No backup manifest file found" in result.output
 
 
 def test_migrate_transform_updates_manifest_and_rewrites_lp(
@@ -902,6 +1324,67 @@ def test_migrate_transform_reports_tag_to_field_conflicts(
     assert manifest["files"][0]["last_error"] is not None
 
 
+def test_migrate_transform_defaults_to_all_shards(
+    tmp_path: Path,
+) -> None:
+    """Transform should default to the all-shards run."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text("- op: drop-tag\n  tag: region\n", encoding="utf-8")
+
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    file_paths = _write_all_exported_lp(
+        work_dir,
+        {
+            "975": "weather,region=us temp=82\n",
+            "986": "cpu,region=us value=1i\n",
+        },
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Transformed 2 file(s).\n"
+    assert file_paths["975"].read_text(encoding="utf-8") == "weather temp=82\n"
+    assert file_paths["986"].read_text(encoding="utf-8") == "cpu value=1i\n"
+
+
 def test_migrate_import_updates_manifest_and_rewrites_headers(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1222,3 +1705,137 @@ def test_migrate_import_records_subprocess_failure(
     assert result.exit_code != 0
     manifest = _read_manifest(work_dir)
     assert manifest["files"][0]["last_error"] == "boom"
+
+
+def test_migrate_import_defaults_to_all_shards(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Import should default to the all-shards run."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--all-shards",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    file_paths = _write_all_exported_lp(
+        work_dir,
+        {
+            "975": "weather temp=82\n",
+            "986": "# DML\n# CONTEXT-DATABASE: lsst.square.metrics\n"
+            "# CONTEXT-RETENTION-POLICY: autogen\ncpu value=1i\n",
+        },
+    )
+    _mark_transformed(work_dir)
+
+    calls: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "imported", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "import",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--work-dir",
+            str(work_dir),
+            "--host",
+            "influxdb.example.org",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == (
+        f"Added import headers to {file_paths['975']} for "
+        "database=lsst.square.metrics, retention=autogen.\n"
+        "Imported 2 file(s).\n"
+    )
+    assert len(calls) == 2
+
+
+def test_explicit_shard_runs_remain_isolated_from_all_shards(
+    tmp_path: Path,
+) -> None:
+    """Explicit shard runs should stay isolated from implicit all-shards."""
+    backup_dir = _create_backup_tree(tmp_path)
+    work_dir = tmp_path / "work"
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text("- op: drop-tag\n  tag: region\n", encoding="utf-8")
+
+    runner = CliRunner()
+    discover_result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "discover",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--shard",
+            "975",
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+    assert discover_result.exit_code == 0
+    _write_exported_lp(work_dir, "weather,region=us temp=82\n")
+
+    result = runner.invoke(
+        main,
+        [
+            "influxdb",
+            "migrate",
+            "transform",
+            "--backup-dir",
+            str(backup_dir),
+            "--database",
+            "lsst.square.metrics",
+            "--retention",
+            "autogen",
+            "--work-dir",
+            str(work_dir),
+            "--plan",
+            str(plan_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "No discovered files found in the manifest. Run export first."
+        in result.output
+    )

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -314,6 +314,7 @@ def test_migrate_discover_rejects_missing_shard(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "No TSM files found for shard '998'" in result.output
+    assert not run_dir.exists()
 
 
 def test_migrate_discover_all_shards_uses_backup_manifest(
@@ -381,6 +382,7 @@ def test_migrate_discover_all_shards_requires_backup_manifest(
 
     assert result.exit_code != 0
     assert "No backup manifest file found" in result.output
+    assert not run_dir.exists()
 
 
 def test_migrate_discover_all_shards_rejects_multiple_manifests(
@@ -413,6 +415,7 @@ def test_migrate_discover_all_shards_rejects_multiple_manifests(
 
     assert result.exit_code != 0
     assert "Multiple backup manifest files found" in result.output
+    assert not run_dir.exists()
 
 
 def test_migrate_discover_all_shards_rejects_no_matching_manifest_entries(
@@ -443,6 +446,7 @@ def test_migrate_discover_all_shards_rejects_no_matching_manifest_entries(
 
     assert result.exit_code != 0
     assert "No shard entries found in the backup manifest" in result.output
+    assert not run_dir.exists()
 
 
 def test_migrate_discover_all_shards_rejects_missing_archive(
@@ -475,6 +479,7 @@ def test_migrate_discover_all_shards_rejects_missing_archive(
     assert result.exit_code != 0
     assert "Backup shard archive" in result.output
     assert "is missing." in result.output
+    assert not run_dir.exists()
 
 
 def test_migrate_discover_all_shards_rejects_archive_without_matching_tsm(
@@ -516,6 +521,7 @@ def test_migrate_discover_all_shards_rejects_archive_without_matching_tsm(
 
     assert result.exit_code != 0
     assert "does not contain matching TSM files" in result.output
+    assert not run_dir.exists()
 
 
 def test_migrate_discover_rejects_mixed_shard_selection(

--- a/tests/tag_to_field_test.py
+++ b/tests/tag_to_field_test.py
@@ -22,7 +22,13 @@ def test_convert_tag_to_field_rewrites_line_protocol_file(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "convert-tag-to-field", str(data_file), "region"],
+        [
+            "influxdb",
+            "line-protocol",
+            "convert-tag-to-field",
+            str(data_file),
+            "region",
+        ],
     )
 
     assert result.exit_code == 0
@@ -47,6 +53,7 @@ def test_convert_tag_to_field_can_be_scoped_to_one_measurement(
         main,
         [
             "influxdb",
+            "line-protocol",
             "convert-tag-to-field",
             "--measurement",
             "weather",
@@ -74,7 +81,13 @@ def test_convert_tag_to_field_escapes_string_field_values(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "convert-tag-to-field", str(data_file), "note"],
+        [
+            "influxdb",
+            "line-protocol",
+            "convert-tag-to-field",
+            str(data_file),
+            "note",
+        ],
     )
 
     assert result.exit_code == 0
@@ -94,7 +107,13 @@ def test_convert_tag_to_field_aborts_if_field_key_already_exists(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "convert-tag-to-field", str(data_file), "region"],
+        [
+            "influxdb",
+            "line-protocol",
+            "convert-tag-to-field",
+            str(data_file),
+            "region",
+        ],
     )
 
     assert result.exit_code != 0
@@ -115,7 +134,14 @@ def test_convert_tag_to_field_verbose_reports_modified_line_count(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "convert-tag-to-field", "-v", str(data_file), "region"],
+        [
+            "influxdb",
+            "line-protocol",
+            "convert-tag-to-field",
+            "-v",
+            str(data_file),
+            "region",
+        ],
     )
 
     assert result.exit_code == 0

--- a/tests/tag_to_field_test.py
+++ b/tests/tag_to_field_test.py
@@ -8,6 +8,21 @@ from click.testing import CliRunner
 
 from sasquatch.cli import main
 
+EXPORT_HEADER = (
+    "# INFLUXDB EXPORT: 1677-09-21T00:12:43Z - 2262-04-11T23:47:16Z\n"
+    "# DDL\n"
+    'CREATE DATABASE "target.metrics"\n'
+    "# DML\n"
+    "# CONTEXT-DATABASE:target.metrics\n"
+    "# CONTEXT-RETENTION-POLICY:forever\n"
+    "# writing tsm data\n"
+)
+
+
+def _with_header(content: str) -> str:
+    """Prefix synthetic line protocol with a realistic export header."""
+    return EXPORT_HEADER + content
+
 
 def test_convert_tag_to_field_rewrites_line_protocol_file(
     tmp_path: Path,
@@ -15,7 +30,9 @@ def test_convert_tag_to_field_rewrites_line_protocol_file(
     """The CLI should convert the tag and drop it from the series key."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us,zone=north temp=82\ncpu,region=us value=1i\n",
+        _with_header(
+            "weather,region=us,zone=north temp=82\ncpu,region=us value=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -33,7 +50,7 @@ def test_convert_tag_to_field_rewrites_line_protocol_file(
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         'weather,zone=north temp=82,region="us"\ncpu value=1i,region="us"\n'
     )
 
@@ -44,7 +61,7 @@ def test_convert_tag_to_field_can_be_scoped_to_one_measurement(
     """Measurement scoping should preserve tags on other measurements."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us temp=82\ncpu,region=us value=1i\n",
+        _with_header("weather,region=us temp=82\ncpu,region=us value=1i\n"),
         encoding="utf-8",
     )
 
@@ -63,7 +80,7 @@ def test_convert_tag_to_field_can_be_scoped_to_one_measurement(
     )
 
     assert result.exit_code == 0
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         'weather temp=82,region="us"\ncpu,region=us value=1i\n'
     )
 
@@ -74,7 +91,9 @@ def test_convert_tag_to_field_escapes_string_field_values(
     """Converted field values should remain valid string fields."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        'weather,summary=hot\\,\\ dry\\ day,note=he\\ said\\"hi temp=82\n',
+        _with_header(
+            'weather,summary=hot\\,\\ dry\\ day,note=he\\ said\\"hi temp=82\n'
+        ),
         encoding="utf-8",
     )
 
@@ -91,7 +110,7 @@ def test_convert_tag_to_field_escapes_string_field_values(
     )
 
     assert result.exit_code == 0
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         'weather,summary=hot\\,\\ dry\\ day temp=82,note="he said\\"hi"\n'
     )
 
@@ -102,7 +121,7 @@ def test_convert_tag_to_field_aborts_if_field_key_already_exists(
     """Existing field keys should abort without changing the file."""
     data_file = tmp_path / "data.lp"
     original = 'weather,region=us temp=82,region="west"\n'
-    data_file.write_text(original, encoding="utf-8")
+    data_file.write_text(_with_header(original), encoding="utf-8")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -118,7 +137,7 @@ def test_convert_tag_to_field_aborts_if_field_key_already_exists(
 
     assert result.exit_code != 0
     assert "field already exists" in result.output
-    assert data_file.read_text(encoding="utf-8") == original
+    assert data_file.read_text(encoding="utf-8") == _with_header(original)
 
 
 def test_convert_tag_to_field_verbose_reports_modified_line_count(
@@ -127,7 +146,7 @@ def test_convert_tag_to_field_verbose_reports_modified_line_count(
     """Verbose mode should report how many lines were modified."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us temp=82\ncpu,region=us value=1i\n",
+        _with_header("weather,region=us temp=82\ncpu,region=us value=1i\n"),
         encoding="utf-8",
     )
 
@@ -146,6 +165,6 @@ def test_convert_tag_to_field_verbose_reports_modified_line_count(
 
     assert result.exit_code == 0
     assert result.output == "Modified 2 lines.\n"
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         'weather temp=82,region="us"\ncpu value=1i,region="us"\n'
     )

--- a/tests/tags_test.py
+++ b/tests/tags_test.py
@@ -9,6 +9,21 @@ from click.testing import CliRunner
 from sasquatch.cli import main
 from sasquatch.tags import extract_measurement_tag_keys
 
+EXPORT_HEADER = (
+    "# INFLUXDB EXPORT: 1677-09-21T00:12:43Z - 2262-04-11T23:47:16Z\n"
+    "# DDL\n"
+    'CREATE DATABASE "target.metrics"\n'
+    "# DML\n"
+    "# CONTEXT-DATABASE:target.metrics\n"
+    "# CONTEXT-RETENTION-POLICY:forever\n"
+    "# writing tsm data\n"
+)
+
+
+def _with_header(content: str) -> str:
+    """Prefix synthetic line protocol with a realistic export header."""
+    return EXPORT_HEADER + content
+
 
 def test_extract_measurement_tag_keys_with_escaped_separators(
     tmp_path: Path,
@@ -21,7 +36,7 @@ def test_extract_measurement_tag_keys_with_escaped_separators(
         "humidity=41"
     )
     data_file = tmp_path / "data.lp"
-    data_file.write_text(line_protocol, encoding="utf-8")
+    data_file.write_text(_with_header(line_protocol), encoding="utf-8")
 
     assert extract_measurement_tag_keys(data_file) == {
         "weather station": ["region", "tag,key"],
@@ -34,7 +49,7 @@ def test_extract_measurement_tag_keys_keeps_measurements_without_tags(
     """Measurements without tags should still be reported."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "cpu value=1i\ndisk,device=sda1 used_percent=73.2",
+        _with_header("cpu value=1i\ndisk,device=sda1 used_percent=73.2"),
         encoding="utf-8",
     )
 
@@ -50,8 +65,10 @@ def test_extract_measurement_tag_keys_ignores_comments_and_blank_lines(
     """Comments and blank lines should not affect parsing."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "\n# this is a comment\nsystem,host=foo load=1\n   \n"
-        "# another comment",
+        _with_header(
+            "\n# this is a comment\nsystem,host=foo load=1\n   \n"
+            "# another comment"
+        ),
         encoding="utf-8",
     )
 
@@ -64,7 +81,7 @@ def test_extract_measurement_tag_keys_allows_escaped_equals_in_tag_values(
     """An escaped equals sign in a tag value should not split the tag."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        (
+        _with_header(
             "requests,path=/api/v1,label=build\\=stable,status=200 "
             "duration_ms=12"
         ),
@@ -82,10 +99,13 @@ def test_drop_measurement_tag_key_rewrites_line_protocol_file(
     """The CLI should remove matching tags and keep the rest unchanged."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "# comment\n"
-        "weather\\ station,region=us\\ west,tag\\,key=value\\,one temp=82\n"
-        "weather\\ station,region=us\\ west,zone=north humidity=41\n"
-        "cpu value=1i\n",
+        _with_header(
+            "# comment\n"
+            "weather\\ station,region=us\\ west,"
+            "tag\\,key=value\\,one temp=82\n"
+            "weather\\ station,region=us\\ west,zone=north humidity=41\n"
+            "cpu value=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -97,7 +117,7 @@ def test_drop_measurement_tag_key_rewrites_line_protocol_file(
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "# comment\n"
         "weather\\ station,tag\\,key=value\\,one temp=82\n"
         "weather\\ station,zone=north humidity=41\n"
@@ -111,7 +131,7 @@ def test_drop_measurement_tag_key_matches_unescaped_tag_keys(
     """Dropping a tag should work even when the key is escaped in the file."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "measurement,tag\\,key=value,region=us field=1\n",
+        _with_header("measurement,tag\\,key=value,region=us field=1\n"),
         encoding="utf-8",
     )
 
@@ -122,7 +142,7 @@ def test_drop_measurement_tag_key_matches_unescaped_tag_keys(
     )
 
     assert result.exit_code == 0
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "measurement,region=us field=1\n"
     )
 
@@ -133,9 +153,11 @@ def test_drop_measurement_tag_key_verbose_reports_modified_line_count(
     """Verbose mode should report how many lines changed."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us temp=82\n"
-        "weather,region=us,zone=north humidity=41\n"
-        "cpu value=1i\n",
+        _with_header(
+            "weather,region=us temp=82\n"
+            "weather,region=us,zone=north humidity=41\n"
+            "cpu value=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -154,7 +176,7 @@ def test_drop_measurement_tag_key_verbose_reports_modified_line_count(
 
     assert result.exit_code == 0
     assert result.output == "Modified 2 lines.\n"
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather temp=82\nweather,zone=north humidity=41\ncpu value=1i\n"
     )
 
@@ -165,9 +187,11 @@ def test_drop_measurement_tag_key_can_be_scoped_to_one_measurement(
     """Measurement scoping should preserve matching tags elsewhere."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us,zone=north temp=82\n"
-        "cpu,region=us host=worker-1 value=1i\n"
-        "weather,region=eu humidity=41\n",
+        _with_header(
+            "weather,region=us,zone=north temp=82\n"
+            "cpu,region=us host=worker-1 value=1i\n"
+            "weather,region=eu humidity=41\n"
+        ),
         encoding="utf-8",
     )
 
@@ -187,7 +211,7 @@ def test_drop_measurement_tag_key_can_be_scoped_to_one_measurement(
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather,zone=north temp=82\n"
         "cpu,region=us host=worker-1 value=1i\n"
         "weather humidity=41\n"
@@ -200,9 +224,11 @@ def test_drop_measurement_tag_key_verbose_reports_scoped_line_count(
     """Count only modified lines in the target measurement."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us temp=82\n"
-        "cpu,region=us value=1i\n"
-        "weather,region=eu,zone=north humidity=41\n",
+        _with_header(
+            "weather,region=us temp=82\n"
+            "cpu,region=us value=1i\n"
+            "weather,region=eu,zone=north humidity=41\n"
+        ),
         encoding="utf-8",
     )
 
@@ -223,7 +249,7 @@ def test_drop_measurement_tag_key_verbose_reports_scoped_line_count(
 
     assert result.exit_code == 0
     assert result.output == "Modified 2 lines.\n"
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather temp=82\n"
         "cpu,region=us value=1i\n"
         "weather,zone=north humidity=41\n"
@@ -234,9 +260,11 @@ def test_rename_tag_rewrites_line_protocol_file(tmp_path: Path) -> None:
     """The CLI should rename matching tags and keep the rest unchanged."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "# comment\n"
-        "weather,region=us,zone=north temp=82\n"
-        "cpu,region=us value=1i\n",
+        _with_header(
+            "# comment\n"
+            "weather,region=us,zone=north temp=82\n"
+            "cpu,region=us value=1i\n"
+        ),
         encoding="utf-8",
     )
 
@@ -255,7 +283,7 @@ def test_rename_tag_rewrites_line_protocol_file(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "# comment\nweather,site=us,zone=north temp=82\ncpu,site=us value=1i\n"
     )
 
@@ -264,9 +292,11 @@ def test_rename_tag_can_be_scoped_to_one_measurement(tmp_path: Path) -> None:
     """Measurement scoping should preserve matching tags elsewhere."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us,zone=north temp=82\n"
-        "cpu,region=us value=1i\n"
-        "weather,region=eu humidity=41\n",
+        _with_header(
+            "weather,region=us,zone=north temp=82\n"
+            "cpu,region=us value=1i\n"
+            "weather,region=eu humidity=41\n"
+        ),
         encoding="utf-8",
     )
 
@@ -287,7 +317,7 @@ def test_rename_tag_can_be_scoped_to_one_measurement(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather,site=us,zone=north temp=82\n"
         "cpu,region=us value=1i\n"
         "weather,site=eu humidity=41\n"
@@ -300,7 +330,7 @@ def test_rename_tag_escapes_new_tag_key_and_reports_verbose_count(
     """Verbose mode should report changes and escaped new keys stay valid."""
     data_file = tmp_path / "data.lp"
     data_file.write_text(
-        "weather,region=us temp=82\ncpu,region=us value=1i\n",
+        _with_header("weather,region=us temp=82\ncpu,region=us value=1i\n"),
         encoding="utf-8",
     )
 
@@ -322,6 +352,6 @@ def test_rename_tag_escapes_new_tag_key_and_reports_verbose_count(
 
     assert result.exit_code == 0
     assert result.output == "Modified 1 lines.\n"
-    assert data_file.read_text(encoding="utf-8") == (
+    assert data_file.read_text(encoding="utf-8") == _with_header(
         "weather,site\\ area=us temp=82\ncpu,region=us value=1i\n"
     )

--- a/tests/tags_test.py
+++ b/tests/tags_test.py
@@ -92,7 +92,7 @@ def test_drop_measurement_tag_key_rewrites_line_protocol_file(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "drop-tag", str(data_file), "region"],
+        ["influxdb", "line-protocol", "drop-tag", str(data_file), "region"],
     )
 
     assert result.exit_code == 0
@@ -118,7 +118,7 @@ def test_drop_measurement_tag_key_matches_unescaped_tag_keys(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "drop-tag", str(data_file), "tag,key"],
+        ["influxdb", "line-protocol", "drop-tag", str(data_file), "tag,key"],
     )
 
     assert result.exit_code == 0
@@ -142,7 +142,14 @@ def test_drop_measurement_tag_key_verbose_reports_modified_line_count(
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "drop-tag", "-v", str(data_file), "region"],
+        [
+            "influxdb",
+            "line-protocol",
+            "drop-tag",
+            "-v",
+            str(data_file),
+            "region",
+        ],
     )
 
     assert result.exit_code == 0
@@ -169,6 +176,7 @@ def test_drop_measurement_tag_key_can_be_scoped_to_one_measurement(
         main,
         [
             "influxdb",
+            "line-protocol",
             "drop-tag",
             "--measurement",
             "weather",
@@ -203,6 +211,7 @@ def test_drop_measurement_tag_key_verbose_reports_scoped_line_count(
         main,
         [
             "influxdb",
+            "line-protocol",
             "drop-tag",
             "-v",
             "-m",
@@ -234,7 +243,14 @@ def test_rename_tag_rewrites_line_protocol_file(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["influxdb", "rename-tag", str(data_file), "region", "site"],
+        [
+            "influxdb",
+            "line-protocol",
+            "rename-tag",
+            str(data_file),
+            "region",
+            "site",
+        ],
     )
 
     assert result.exit_code == 0
@@ -259,6 +275,7 @@ def test_rename_tag_can_be_scoped_to_one_measurement(tmp_path: Path) -> None:
         main,
         [
             "influxdb",
+            "line-protocol",
             "rename-tag",
             "--measurement",
             "weather",
@@ -292,6 +309,7 @@ def test_rename_tag_escapes_new_tag_key_and_reports_verbose_count(
         main,
         [
             "influxdb",
+            "line-protocol",
             "rename-tag",
             "-v",
             "-m",

--- a/uv.lock
+++ b/uv.lock
@@ -563,7 +563,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
     { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
     { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
     { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
     { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
@@ -571,7 +573,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
     { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
     { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
@@ -1709,6 +1713,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "safir" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1742,6 +1747,7 @@ tox = [
 ]
 typing = [
     { name = "mypy" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -1749,6 +1755,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.100" },
     { name = "pydantic", specifier = ">2" },
     { name = "pydantic-settings", specifier = ">=2" },
+    { name = "pyyaml", specifier = ">=6" },
     { name = "safir", specifier = ">=5" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
@@ -1780,7 +1787,10 @@ tox = [
     { name = "tox", specifier = ">=4.24" },
     { name = "tox-uv", specifier = ">=1.25" },
 ]
-typing = [{ name = "mypy", specifier = ">=1.19" }]
+typing = [
+    { name = "mypy", specifier = ">=1.19" },
+    { name = "types-pyyaml" },
+]
 
 [[package]]
 name = "scriv"
@@ -2320,6 +2330,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -79,6 +79,44 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-serialize"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1f/50f241d4e01fe75f4bba6a209edd4047c4b26acf70992ff885fd161f79cb/ast_serialize-0.4.0.tar.gz", hash = "sha256:74e4e634ab82d1466acf0be27043178570b98ebeaa3165f9240a6fad4c286471", size = 60687, upload-time = "2026-05-14T22:44:38.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/85/232631c59b5ca7152c08f026e9a46f47d852298acff74edd04a1fc1d0005/ast_serialize-0.4.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:a6f26937ce0293aafbece0e39019e020369a5a70486ff4088227f0cc888844a9", size = 1182685, upload-time = "2026-05-14T22:43:40.205Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/4838d4d3ddc4425555601467d4e2a565e4340899e45feee4e32c80fbc911/ast_serialize-0.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:074032142777e3e6091977dc3c5146a8ca58ae6825b7f64e9a0b604153ddabd8", size = 1173113, upload-time = "2026-05-14T22:43:41.937Z" },
+    { url = "https://files.pythonhosted.org/packages/22/fc/d622b19fc1c79a62028ec17f4ad4323177af25b174d32b07c84d61ef9d47/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:404f3462b4532e13a70b8849bba241dbd82e30043ff58d98c7e762fd925b116a", size = 1234117, upload-time = "2026-05-14T22:43:43.977Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b5/72f8c8659da0b64562e6d97f852d5c2022c74577df27c922e1e7065039ce/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:97c55336e16f5c4ca2bde7be94cca4b8f7d665d64f7008925a82e02707ba14ac", size = 1231703, upload-time = "2026-05-14T22:43:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/98/ccc51ee4f90f97a1ed0a0848bd4c9d77a80969849db8a262b7d2970a6a15/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:732b4ef76adcb0f298a7d18c4558336d83b1384f9ae0c7eaa1dc8d031b0a4390", size = 1441574, upload-time = "2026-05-14T22:43:47.784Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ce/668c4efe79e09c9cc97a4d0a1c29e61fe6f78857fe1e57c086772af55f89/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b3db87c4772097c0782250bcd550d66b1189a8c889793c7bcf153f4fee70005c", size = 1254040, upload-time = "2026-05-14T22:43:49.879Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/be/38b27bc2909b7236939801ca9f0d97cdc6198da4f435a81658e0db506fdb/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43729a5e369ebbe7750635c0c206bc616fcd36e703cb9c4497d6b4df0291ee64", size = 1257847, upload-time = "2026-05-14T22:43:51.607Z" },
+    { url = "https://files.pythonhosted.org/packages/68/df/360ebccc361235c167a8be2a0476870cb9ef44c42413bf1289b885684052/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:91d3786f3929786cdc4eeedfd110abb4603e7f6c1390c5af398f333a947b742d", size = 1298683, upload-time = "2026-05-14T22:43:53.606Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5c/7d5e0b4d47aafa1600c19e3670f962f81a9bf3da1bc25a1382529a447cf3/ast_serialize-0.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7fba7315fd4bd87cb5560792709f6e66e0606402d362c0a38dd32dfb66ba6066", size = 1409438, upload-time = "2026-05-14T22:43:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/3d/8875b2f1af3ec1539b88ff193dfbfa5573084ef7fcab27ea4cd09b6dc829/ast_serialize-0.4.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4db9769d57deb5545ce56ebbbbe3436dcc0ae2688ce14c295cd14e106624ece7", size = 1507922, upload-time = "2026-05-14T22:43:56.959Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/5ec6927eb493ece7ba64263cdc556be889e0c62a013b1851bbe674a0dcda/ast_serialize-0.4.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:dcd04f85a29deb80400e8987cfaceb9907140f763453cbffdbd6ff36f1b32c12", size = 1502817, upload-time = "2026-05-14T22:43:59.081Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c8/40cb818a08396b1f34d6189c0c42aec917dd331e11fb7c3b870cc61b795a/ast_serialize-0.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:905fc11940831454d93589bd7ce2acb6a5eb01c2936156f751d2a21087c98cd3", size = 1454318, upload-time = "2026-05-14T22:44:01.377Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d5/d51494b60cc52f4792be5ddc951631cddb17a2990154634549abdbdbb5bf/ast_serialize-0.4.0-cp314-cp314t-win32.whl", hash = "sha256:3bdde2c4570143791f636aed4e3ef868f5b46eb90a18f8d5c41dd045aab08bef", size = 1060098, upload-time = "2026-05-14T22:44:03.265Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c9/b0086257c79ff95743a3621448a01fc71b234ae359d3d54cda383aa43939/ast_serialize-0.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6551d55b8607b97a7755683d743200b398c61a0b71a11b7f00c89c335a11d0f4", size = 1101015, upload-time = "2026-05-14T22:44:05.055Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6d/3dfddef4990fda47745af6615a3e51c4de711eda56c3a8072a0d8b6181c7/ast_serialize-0.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7234ff086cb152ea2a3b7ef895b5ebeb6d80779df049d5c6431c8e3536d5b03c", size = 1074495, upload-time = "2026-05-14T22:44:07.186Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d5/044c5f995ef75807a0effb56fc288cfdedeeb571222450fb6f7d94fd52f1/ast_serialize-0.4.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dcded5056d9f3d201df7833082c07ebcbc566ffc3d4105c9fc9fe278fa086ecb", size = 1189800, upload-time = "2026-05-14T22:44:09.333Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5a/52163557789d59a8197c10912ab4a1791c9143731ba0e3d9283ac0791db6/ast_serialize-0.4.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bd50d201098aae0d202805fe9606c0545492f69a3ec4403337e32c54ad29fc41", size = 1181713, upload-time = "2026-05-14T22:44:11.286Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c3/678ce3b6cb594b01c361da87f6c5679d26c1dae1583a082a8cd190e7232e/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6615b39cd747967c3aabe68bf3f5f26748e823cc6b474ddc1510ed188a824149", size = 1243258, upload-time = "2026-05-14T22:44:13.345Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dd/4810fbeb81c47b7e4e65db15ca65c71330efc59b460bd10c12338dc6012e/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91362c0a9fdf1c344b7f50a5b0508b11a0732102998fbd754a191f7187e77031", size = 1239226, upload-time = "2026-05-14T22:44:15.811Z" },
+    { url = "https://files.pythonhosted.org/packages/28/38/13a88d90b664c009ed208346ec2ed248b0ab2cb0b582ae467acaa7f44fa4/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:70d9c5d527bbfa69bd3c7d17dac11fb6781e36186a434a06d7d5892e0b2f88f9", size = 1448867, upload-time = "2026-05-14T22:44:17.99Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/a069dba1a634b703bf07fb49df8f7e3c04e9ba8ef3f0d9f4495f72630f92/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4738790cf54d8b416de992b87ee567056980bc82134d52458bd4985f389d1658", size = 1264135, upload-time = "2026-05-14T22:44:19.8Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4c/76ec4279fecd7e78b60c3c99321f944c43cd11e5ff09c952746f5f9c0f4c/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:faa008dccfcb793ae9101325e4d6d026caaa5d845c2182f03749c759834b0a3a", size = 1269060, upload-time = "2026-05-14T22:44:21.894Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c5/9230ef7481e5cb63b93a1f7738e959586202b081caf32b8bc5d9f673ef56/ast_serialize-0.4.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1c5245228e65d38cb48e1251f0ca71b0fa417e527141491e8c92f740e8e2d121", size = 1309654, upload-time = "2026-05-14T22:44:23.725Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/54/7d7397528d181ad68e476e0c81aa3ceff7d1f1b5c7fa958d6be28628ef16/ast_serialize-0.4.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8f5153e9c44a02e61f4042c5f9249d2e8a759773d621a0b2f445a899e536e181", size = 1418855, upload-time = "2026-05-14T22:44:25.415Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8f/87d6428adaa0986b817404f09329b64f8d2614cfe061ebf4951b4a7e0d19/ast_serialize-0.4.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1e1fb90def261f6a0db885876f7e1a49ad2dbac38ad9f2f62dba2f9543af16e7", size = 1516040, upload-time = "2026-05-14T22:44:27.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/bb/5aaa41a21314c8b0d6dee54867b16535682c6660dd28cac64dba1380062d/ast_serialize-0.4.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf2ff7b654c8e95143e20f5d75878cbb78b65b928b26c4d58ef71cdba9d6d981", size = 1511450, upload-time = "2026-05-14T22:44:29.522Z" },
+    { url = "https://files.pythonhosted.org/packages/87/16/cc729b5bb4b21da99db1379266cc367512e82ba10f9b3300a6f3e9941325/ast_serialize-0.4.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:90fc5c0d35a22f1a92dd33635508626d50f8fc64deb897c23e78e666a60804c9", size = 1463654, upload-time = "2026-05-14T22:44:31.265Z" },
+    { url = "https://files.pythonhosted.org/packages/43/97/7198321b0244d011093387b41affea934d58bda08d59a2adfde72976b6c4/ast_serialize-0.4.0-cp39-abi3-win32.whl", hash = "sha256:9ecd6a1fc1b86f1f4e8ae206759b6319c10019706b3496b01b54d02b9b2cd918", size = 1068636, upload-time = "2026-05-14T22:44:33.189Z" },
+    { url = "https://files.pythonhosted.org/packages/10/09/3b868f6d8df4bbe452903a5e0e039ebcec9ea0045f1a77951546205097e8/ast_serialize-0.4.0-cp39-abi3-win_amd64.whl", hash = "sha256:79c8d015c771c8bfdb1208003b227b27c40034790a2c29c09f2317a041825ce2", size = 1107137, upload-time = "2026-05-14T22:44:35.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/78/9387dffccdc55a12734f83aaccc4a987404a217a2a12a1920d8d4585950b/ast_serialize-0.4.0-cp39-abi3-win_arm64.whl", hash = "sha256:1026f565a7ab846337c630909089b3346a2fe417bf1552b1581ab01852137407", size = 1079199, upload-time = "2026-05-14T22:44:36.816Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -133,11 +171,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.0.6"
+version = "7.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/7b/1755ed2c6bfabd1d98b37ae73152f8dcf94aa40fee119d163c19ed484704/cachetools-7.0.6.tar.gz", hash = "sha256:e5d524d36d65703a87243a26ff08ad84f73352adbeafb1cde81e207b456aaf24", size = 37526, upload-time = "2026-04-20T19:02:23.289Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/c4/cf76242a5da1410917107ff14551764aa405a5fd10cd10cf9a5ca8fa77f4/cachetools-7.0.6-py3-none-any.whl", hash = "sha256:4e94956cfdd3086f12042cdd29318f5ced3893014f7d0d059bf3ead3f85b7f8b", size = 13976, upload-time = "2026-04-20T19:02:21.187Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
 ]
 
 [[package]]
@@ -276,94 +314,94 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.13.5"
+version = "7.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74", size = 919489, upload-time = "2026-05-10T18:02:31.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
-    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
-    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
-    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
-    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
-    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
-    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
-    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
-    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
-    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/18/b9a6586d73992807c26f9a5f274131be3d76b56b18a82b9392e2a25d2e45/coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d", size = 220036, upload-time = "2026-05-10T18:01:33.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63", size = 220368, upload-time = "2026-05-10T18:01:34.705Z" },
+    { url = "https://files.pythonhosted.org/packages/69/aa/c12e52a5ba148d9995229d557e3be6e554fe469addc0e9241b2f0956d8ea/coverage-7.14.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3a5d8e876dfa2f102e970b183863d6dedd023d3c0eeca1fe7a9787bc5f28b212", size = 251417, upload-time = "2026-05-10T18:01:36.949Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3", size = 253924, upload-time = "2026-05-10T18:01:38.985Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97", size = 255269, upload-time = "2026-05-10T18:01:40.957Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a9/36dfa153a62040296f6e7febfdb20a5720622f6ef5a81a41e8237b9a5344/coverage-7.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3485a836550b303d006d57cc06e3d5afaabc642c77050b7c985a97b13e3776b8", size = 257583, upload-time = "2026-05-10T18:01:42.607Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7b/cc2c048d4114d9ab1c2409e9ee365e5ae10736df6dffcfc9444effa6c708/coverage-7.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e7e88110bae996d199d1693ca8ec3fd52441d426401ae963437598667b4c5eb", size = 251434, upload-time = "2026-05-10T18:01:44.537Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe", size = 253280, upload-time = "2026-05-10T18:01:46.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/9e/1c0264514a3f98259a6d64765a397b2c8373e3ba59ee722a4802d3ec0c61/coverage-7.14.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9d26ac7f5398bafc5b57421ad994e8a4749e8a7a0e62d05ec7d53014d5963bfa", size = 251241, upload-time = "2026-05-10T18:01:48.732Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/4efdf3e3c4079cdbf0ece56a2fea872df9e8a3e15a13a0af4400e1075944/coverage-7.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2fb73254ff43c911c967a899e1359bc5049b4b115d6e8fbdde4937d0a2246cd5", size = 255516, upload-time = "2026-05-10T18:01:50.819Z" },
+    { url = "https://files.pythonhosted.org/packages/93/69/b1de96346603881b3d1bc8d6447c83200e1c9700ffbaff926ba01ff5724c/coverage-7.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:454a380af72c6adada298ed270d38c7a391288198dbfb8467f786f588751a90c", size = 251059, upload-time = "2026-05-10T18:01:52.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca", size = 252716, upload-time = "2026-05-10T18:01:54.506Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5c/0d3305d002c41dcde873dbe456491e663dc55152ca526b630b5c47efd62f/coverage-7.14.0-cp314-cp314-win32.whl", hash = "sha256:6a6516b02a6101398e19a3f44820f69bab2590697f7def4331f668b14adaf828", size = 222788, upload-time = "2026-05-10T18:01:56.487Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d", size = 223600, upload-time = "2026-05-10T18:01:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/00/70/a18c408e674bc26281cadaedc7351f929bd2094e191e4b15271c30b084cc/coverage-7.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:4b899594a8b2d81e5cc064a0d7f9cac2081fed91049456cae7676787e41549c9", size = 222168, upload-time = "2026-05-10T18:02:00.411Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/89/2681f071d238b62aff8dfc2ab44fc24cfdb38d1c01f391a80522ff5d3a16/coverage-7.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f580f8c80acd94ac72e863efe2cab791d8c38d153e0b463b92dfa000d5c84cd1", size = 220766, upload-time = "2026-05-10T18:02:02.313Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c7/c987babafd9207ffa1995e1ef1f9b26762cf4963aa768a66b6f0501e4616/coverage-7.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a2bd259c442cd43c49b30fbafc51776eb19ea396faf159d26a83e6a0a5f13b0c", size = 221035, upload-time = "2026-05-10T18:02:04.017Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e9/d6a5ac3b333088143d6fc877d398a9a674dc03124a2f776e131f03864823/coverage-7.14.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a706b908dfa85538863504c624b237a3cc34232bf403c057414ebfdb3b4d9f84", size = 262405, upload-time = "2026-05-10T18:02:05.915Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b1/e70838d29a7c08e22d44398a46db90815bbcbf28de06992bd9210d1a8d8e/coverage-7.14.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7333cd944ee4393b9b3d3c1b598c936d4fc8d70573a4c7dacfec5590dd50e436", size = 264530, upload-time = "2026-05-10T18:02:07.582Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/73/5c31ef97763288d03d9995152b96d5475b527c63d91c84b01caea894b83a/coverage-7.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f162bc9a15b82d947b02651b0c7e1609d6f7a8735ca330cfadec8481dd97d5a", size = 266932, upload-time = "2026-05-10T18:02:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/76/dd56d80f29c5f05b4d76f7e7c6d47cafacae017189c75c5759d24f9ff0cc/coverage-7.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:362cb78e01a5dc82009d88004cf60f2e6b6d6fcbfdec05b05af73b0abf40118f", size = 268062, upload-time = "2026-05-10T18:02:11.399Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c7/27ba85cd5b95614f159ff93ebff1901584a8d192e2e5e24c4943a7453f59/coverage-7.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:acebd068fca5512c3a6fde9c045f901613478781a73f0e82b307b214daef23fb", size = 261504, upload-time = "2026-05-10T18:02:13.257Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2e/e8149f60ab5d5684c6eee881bdf34b127115cddbb958b196768dd9d63473/coverage-7.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:29fe3da551dface75deb2ccbf87b6b66e2e7ef38f6d89050b428be94afff3490", size = 264398, upload-time = "2026-05-10T18:02:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7f/1261b025285323225f4b4abffa5a643649dfd67e25ddca7ebcbdea3b7cb3/coverage-7.14.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b4cc4fce8672fffcb09b0eafc167b396b3ba53c4a7230f54b7aaffbf6c835fa9", size = 262000, upload-time = "2026-05-10T18:02:16.756Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/dc/829c54f60b9d08389439c00f813c752781c496fc5788c78d8006db4b4f2b/coverage-7.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5d4a51aad8ba8bdcd2b8bd8f03d4aca19693fa2327a3470e4718a25b03481020", size = 265732, upload-time = "2026-05-10T18:02:18.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b0/70bd1419941652fa062689cba9c3eeafb8f5e6fbb890bce41c3bdda5dbd6/coverage-7.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9f323af3e1e4f68b60b7b247e37b8515563a61375518fa59de1af48ba28a3db6", size = 260847, upload-time = "2026-05-10T18:02:20.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/73/be40b2390656c654d35ea0015ea7ba3d945769cf80790ad5e0bb2d56d2ba/coverage-7.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1a0abc7342ea9711c469dd8b821c6c311e6bc6aac1442e5fbd6b27fae0a8f3db", size = 263166, upload-time = "2026-05-10T18:02:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/29/55/4a643f712fcf7cf2881f8ec1e0ccb7b164aff3108f69b51801246c8799f2/coverage-7.14.0-cp314-cp314t-win32.whl", hash = "sha256:a9f864ef57b7172e2db87a096642dd51e179e085ab6b2c371c29e885f65c8fb2", size = 223573, upload-time = "2026-05-10T18:02:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/27/96/3acae5da0953be042c0b4dea6d6789d2f080701c77b88e44d5bd41b9219b/coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644", size = 224680, upload-time = "2026-05-10T18:02:25.896Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/6ab5d2dd8325d838737c6f8d83d62eb6230e0d70b87b51b57bbfd08fa767/coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b", size = 222703, upload-time = "2026-05-10T18:02:27.822Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
 ]
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
-    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
-    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
-    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -476,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.0"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -485,9 +523,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -535,14 +573,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -556,29 +594,25 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "3.4.0"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
-    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
-    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
-    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
-    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
-    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
-    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
-    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -644,11 +678,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -707,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "9.12.0"
+version = "9.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -717,13 +751,14 @@ dependencies = [
     { name = "matplotlib-inline" },
     { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
     { name = "prompt-toolkit" },
+    { name = "psutil" },
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/22/906c8108974c673ebef6356c506cebb6870d48cedea3c41e949e2dd556bb/ipython-9.12.0-py3-none-any.whl", hash = "sha256:0f2701e8ee86e117e37f50563205d36feaa259d2e08d4a6bc6b6d74b18ce128d", size = 625661, upload-time = "2026-03-27T09:42:42.831Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201", size = 627274, upload-time = "2026-04-24T12:24:53.038Z" },
 ]
 
 [[package]]
@@ -740,14 +775,14 @@ wheels = [
 
 [[package]]
 name = "jedi"
-version = "0.19.2"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "parso" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
 ]
 
 [[package]]
@@ -848,36 +883,36 @@ wheels = [
 
 [[package]]
 name = "librt"
-version = "0.9.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
-    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
-    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
-    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
-    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
-    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
-    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
 ]
 
 [[package]]
@@ -894,14 +929,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [package.optional-dependencies]
@@ -941,26 +976,26 @@ wheels = [
 
 [[package]]
 name = "matplotlib-inline"
-version = "0.2.1"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
 ]
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.5.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -974,31 +1009,32 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.20.2"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "ast-serialize" },
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
-    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
-    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
-    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
-    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
-    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
-    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
-    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
 ]
 
 [[package]]
@@ -1033,7 +1069,7 @@ wheels = [
 
 [[package]]
 name = "myst-parser"
-version = "5.0.0"
+version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -1043,9 +1079,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl", hash = "sha256:ab31e516024918296e169139072b81592336f2fef55b8986aa31c9f04b5f7211", size = 84533, upload-time = "2026-01-15T09:08:16.788Z" },
+    { url = "https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl", hash = "sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a", size = 85817, upload-time = "2026-05-13T09:38:17.904Z" },
 ]
 
 [[package]]
@@ -1098,29 +1134,29 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
 name = "parso"
-version = "0.8.6"
+version = "0.8.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
 ]
 
 [[package]]
 name = "pathspec"
-version = "1.0.4"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -1271,7 +1307,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.13.3"
+version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -1279,64 +1315,64 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.3"
+version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
-    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
-    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
-    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
-    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
-    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
-    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
-    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
-    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
 ]
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.0"
+version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
 ]
 
 [[package]]
@@ -1454,15 +1490,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.2.2"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
 ]
 
 [[package]]
@@ -1546,7 +1582,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1554,9 +1590,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1648,32 +1684,32 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
 ]
 
 [[package]]
 name = "safir"
-version = "15.0.0"
+version = "15.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1689,21 +1725,21 @@ dependencies = [
     { name = "starlette" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/4c/1c8eea1531eb4522ea412e18b1fa2edccb460b095acaa461d50b540e1cac/safir-15.0.0.tar.gz", hash = "sha256:5c9455672abb0a8101cf3b20e6d09362e29d0dd3d475ed74a5d0763b604aa308", size = 558601, upload-time = "2026-04-10T00:20:48.566Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/be/9501453b66537cc4f2dbe24aa0c1680387f79e23594a80f979de6c390ec4/safir-15.1.0.tar.gz", hash = "sha256:e4199f149de2337eebf23b7e4aa503844b38c56086bb8c6e8a24dab54246705c", size = 564831, upload-time = "2026-05-14T15:42:09.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/33/6cb45ff61196f46365d9aa8cf10d4d215196fed2015c9a138c95942edbde/safir-15.0.0-py3-none-any.whl", hash = "sha256:872bb7e350338d11b11bfcf3a66e8129a53f37f7108abdb4b84dde14a6fca694", size = 181382, upload-time = "2026-04-10T00:20:50.183Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c8/47f7af49fe1df0a094c61a78f1b40356573b5b8cd0ddc5a8789a35361475/safir-15.1.0-py3-none-any.whl", hash = "sha256:b6b06f71b2f117a9a57d8f2306cb6e265e1e4345e82101f50b990975782775cc", size = 181563, upload-time = "2026-05-14T15:42:06.943Z" },
 ]
 
 [[package]]
 name = "safir-logging"
-version = "15.0.0"
+version = "15.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/ca/9497dd809e4b7477694d077f5f4bf0ab640751967093c56bc89fb72bf1d0/safir_logging-15.0.0.tar.gz", hash = "sha256:2eae94ced7d56536d63af60ac7feabbcccdfda148df3e5d247679c323922e7b3", size = 8448, upload-time = "2026-04-10T00:20:51.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/74/cdd97c883e786330f648407c1a3b9dc00ae18d56199ad41c3229ee2de147/safir_logging-15.1.0.tar.gz", hash = "sha256:a6769b76462baa8f4bd4bfc8f4e36065b6fe73f9c01a2192ecc59f703b19dccf", size = 8430, upload-time = "2026-05-14T15:42:08.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/05/4b941d117879b7f7d10fd89a9ad9ab7ec68f668dc1fa6dc7f02eb1dea010/safir_logging-15.0.0-py3-none-any.whl", hash = "sha256:ec6f843cd4427e51bf408a9058c1bc271b35398b1239dc3b7f59d6e4c73664ca", size = 10390, upload-time = "2026-04-10T00:20:46.908Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a5/8242ccbda2572c016e60762bddedec6384449b919e336a9847ff76d53f7b/safir_logging-15.1.0-py3-none-any.whl", hash = "sha256:4d84aeb15a621a17d59902df42915fbf4c9a75f833b2f74958c4d6a30ea5b141", size = 10388, upload-time = "2026-05-14T15:42:05.366Z" },
 ]
 
 [[package]]
@@ -1811,15 +1847,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.58.0"
+version = "2.60.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/a2/2e6c090db384cc515069f4f85542bd5baf6786852073020ea73d4a76d3ea/sentry_sdk-2.60.0.tar.gz", hash = "sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978", size = 452946, upload-time = "2026-05-13T13:34:52.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
+    { url = "https://files.pythonhosted.org/packages/29/41/f2b800b7f12a05dd48c2a6280d4dd812d1425fc66ed3fe3fd99420c41d1a/sentry_sdk-2.60.0-py3-none-any.whl", hash = "sha256:28a536c03291c8bcb363cf35c611b32738ec118ff64d8d6383b096448ac4c803", size = 475616, upload-time = "2026-05-13T13:34:50.259Z" },
 ]
 
 [[package]]
@@ -2051,7 +2087,7 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-bibtex"
-version = "2.6.5"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -2059,9 +2095,9 @@ dependencies = [
     { name = "pybtex-docutils" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/83/1488c9879f2fa3c2cbd6f666c7a3a42a1fa9e08462bec73281fa6c092cba/sphinxcontrib_bibtex-2.6.5.tar.gz", hash = "sha256:9b3224dd6fece9268ebd8c905dc0a83ff2f6c54148a9235fe70e9d1e9ff149c0", size = 118462, upload-time = "2025-06-27T10:40:14.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/6a/8e0b2c2420286389e7fed78ff361ec30e2f1d58c8560af8d64df5e7b61e0/sphinxcontrib_bibtex-2.7.0.tar.gz", hash = "sha256:fee700f7aae29bb8f654c62913f00d34ac44fc0b8ca0fa67ac922ff4453addee", size = 120669, upload-time = "2026-05-06T09:29:24.935Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a0/3a612da94f828f26cabb247817393e79472c32b12c49222bf85fb6d7b6c8/sphinxcontrib_bibtex-2.6.5-py3-none-any.whl", hash = "sha256:455ea4509642ea0b28ede3721550273626f85af65af01f161bfd8e19dc1edd7d", size = 40410, upload-time = "2025-06-27T10:40:12.274Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c0/d28e62407f4733bbe0169287bc012f0ac3b4a2021066b285570654119c8b/sphinxcontrib_bibtex-2.7.0-py3-none-any.whl", hash = "sha256:28cf0ec7a957d1c7548d5749317ed472ce877e1b629f430f88e3789aa51f87b1", size = 40287, upload-time = "2026-05-06T09:29:23.253Z" },
 ]
 
 [[package]]
@@ -2105,16 +2141,16 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-mermaid"
-version = "2.0.1"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "pyyaml" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/ae/999891de292919b66ea34f2c22fc22c9be90ab3536fbc0fca95716277351/sphinxcontrib_mermaid-2.0.1.tar.gz", hash = "sha256:a21a385a059a6cafd192aa3a586b14bf5c42721e229db67b459dc825d7f0a497", size = 19839, upload-time = "2026-03-05T14:10:41.901Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/3a1cc926da8c563c58ddc124a7b3fe5ccadcae96c96e3a6f8ac3653a210a/sphinxcontrib_mermaid-2.0.2.tar.gz", hash = "sha256:f09576c78ca93fa0e3034fd9c45aaffa7c44ab449de9c43b8b8d262afe52bc66", size = 19265, upload-time = "2026-05-05T13:59:02.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/46/25d64bcd7821c8d6f1080e1c43d5fcdfc442a18f759a230b5ccdc891093e/sphinxcontrib_mermaid-2.0.1-py3-none-any.whl", hash = "sha256:9dca7fbe827bad5e7e2b97c4047682cfd26e3e07398cfdc96c7a8842ae7f06e7", size = 14064, upload-time = "2026-03-05T14:10:40.533Z" },
+    { url = "https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl", hash = "sha256:d862e514991279fb4816302c5cfe167d2557bf3ce7125ae0cb47dac80a0f46ce", size = 14094, upload-time = "2026-05-05T13:59:01.585Z" },
 ]
 
 [[package]]
@@ -2253,11 +2289,11 @@ wheels = [
 
 [[package]]
 name = "tomlkit"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]
@@ -2279,7 +2315,7 @@ wheels = [
 
 [[package]]
 name = "tox"
-version = "4.53.0"
+version = "4.54.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -2293,52 +2329,52 @@ dependencies = [
     { name = "tomli-w" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/01/d87a00063fa670ce4c48a9706b615a95ddf2c9ef5558d43af6071f166fd4/tox-4.53.0.tar.gz", hash = "sha256:62c780e42f87d34ee60f2ea20342156253794fdcbd6885fd797d98ee05009f22", size = 274048, upload-time = "2026-04-14T13:44:13.782Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/2c/7ca5edb5ecd6bcc5cc926fe87e62a84dcd3cbd03a32f9d0bee98d2bee7cf/tox-4.54.0.tar.gz", hash = "sha256:21e36fd8256590379620848d0b03b52f4d541b65b749de1a17c3e616978dad58", size = 279256, upload-time = "2026-05-12T19:13:05.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/03/02e2a03f3756cfb66e7e1bac41b06953f12cec75ddb961d56695d4d43dc4/tox-4.53.0-py3-none-any.whl", hash = "sha256:cc4e716d18c4889aa179d785175c438fa60c35deef20ce689ec288d8fb656096", size = 212164, upload-time = "2026-04-14T13:44:11.997Z" },
+    { url = "https://files.pythonhosted.org/packages/26/18/20cf56a76c5d6117547179db9b5d31cc56e3e90507d1b0b748da74aa95c5/tox-4.54.0-py3-none-any.whl", hash = "sha256:a2d7c1177242ae9c3d9e404039e9f945ce16a3e5dfc66972c643e27d7e764f4b", size = 214527, upload-time = "2026-05-12T19:13:04.334Z" },
 ]
 
 [[package]]
 name = "tox-uv"
-version = "1.35.1"
+version = "1.35.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tox-uv-bare" },
     { name = "uv" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/b1/652dcd3b7d6cb027a0c3b5aa951168f3ace9060f77eff882c7c889942a71/tox_uv-1.35.1-py3-none-any.whl", hash = "sha256:a3e2c320cf6e75d20e71be8493fd48b208614d733ebfbc70f23e6731230e0e65", size = 6565, upload-time = "2026-04-10T16:12:58.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/6e9994c799bdbb309f829dd6b8d98764dd0757302f3433c380438a3a127b/tox_uv-1.35.2-py3-none-any.whl", hash = "sha256:2d99b0e3c782ba49e7cbe521c8d344758595961b17a3633738d67096641c1bde", size = 6565, upload-time = "2026-05-05T01:34:16.07Z" },
 ]
 
 [[package]]
 name = "tox-uv-bare"
-version = "1.35.1"
+version = "1.35.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "tox" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/d8/d65653a00b3e438625a25b7c931e96dc9721d8d8a8b3372ceeb1f83e60e5/tox_uv_bare-1.35.1.tar.gz", hash = "sha256:ea4c3b5a4013e04ca31d99a1d930917b7cc5378e202739e600c8f4a15562e662", size = 32003, upload-time = "2026-04-10T16:13:01.265Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/cb/168dc1ccf24e4065a9a0a33df55709ed2b5eb73bd2b13ddd53187e5dffb8/tox_uv_bare-1.35.2.tar.gz", hash = "sha256:49e28a804c97f23ea17e25859960c0fa78f35bccb7e14344cfd840e89a9aade9", size = 32333, upload-time = "2026-05-05T01:34:18.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/12/a5eca5cde48b06a9aef319bc2cd8b5629eb1bd9207b6e3449ae009ee4021/tox_uv_bare-1.35.1-py3-none-any.whl", hash = "sha256:0b8d12d45f195a521d4f6aac5e42869f0a733c80d86575da855494444f60be74", size = 22243, upload-time = "2026-04-10T16:12:59.735Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/53/4a33dc81da39db7b31e5622333df361e8fe055b7ec636bd5fea762c9182d/tox_uv_bare-1.35.2-py3-none-any.whl", hash = "sha256:c0d590a41d1054a1ad0874e9e5943ff52402786e3d4599d8f8d37a65b566ef53", size = 22307, upload-time = "2026-05-05T01:34:17.681Z" },
 ]
 
 [[package]]
 name = "traitlets"
-version = "5.14.3"
+version = "5.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+    { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
 ]
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260408"
+version = "6.0.12.20260510"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/85/0d9fafce21be112e977a89677f1ce9d1aef921d745b17c758c93e861c11f/types_pyyaml-6.0.12.20260510.tar.gz", hash = "sha256:09c1f1cb65a6eebea1e2e51ccf4918b8288e152909609a35cdb0d805efd125ad", size = 17831, upload-time = "2026-05-10T05:26:28.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ad/fd618a218925daada7b8a5e7326e662599fa5fdff4a4c44ab2795bd2d9ca/types_pyyaml-6.0.12.20260510-py3-none-any.whl", hash = "sha256:3492eb9ba4d9d833473214c4d5736cccf5f37d93f5854059721e1c84f785309d", size = 20304, upload-time = "2026-05-10T05:26:26.981Z" },
 ]
 
 [[package]]
@@ -2382,50 +2418,50 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
 name = "uv"
-version = "0.11.7"
+version = "0.11.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/7d/17750123a8c8e324627534fe1ae2e7a46689db8492f1a834ab4fd229a7d8/uv-0.11.7.tar.gz", hash = "sha256:46d971489b00bdb27e0aa715e4a5cd4ef2c28ea5b6ef78f2b67bf861eb44b405", size = 4083385, upload-time = "2026-04-15T21:42:55.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/a3/be4a946c7c2fc4094c020c8f7d8bd0a739bad55ebe4e2817d6e2b1bc6bff/uv-0.11.14.tar.gz", hash = "sha256:0ea006a117b586b2681b6dfd9703a540d2ad2a136ec0f48d272767e599cc3dfb", size = 4130699, upload-time = "2026-05-12T18:00:37.321Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/5b/2bb2ab6fe6c78c2be10852482ef0cae5f3171460a6e5e24c32c9a0843163/uv-0.11.7-py3-none-linux_armv6l.whl", hash = "sha256:f422d39530516b1dfb28bb6e90c32bb7dacd50f6a383cd6e40c1a859419fbc8c", size = 23757265, upload-time = "2026-04-15T21:43:14.494Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/f5/36ff27b01e60a88712628c8a5a6003b8e418883c24e084e506095844a797/uv-0.11.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8b2fe1ec6775dad10183e3fdce430a5b37b7857d49763c884f3a67eaa8ca6f8a", size = 23184529, upload-time = "2026-04-15T21:42:30.225Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/fa/f379be661316698f877e78f4c51e5044be0b6f390803387237ad92c4057f/uv-0.11.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:162fa961a9a081dcea6e889c79f738a5ae56507047e4672964972e33c301bea9", size = 21780167, upload-time = "2026-04-15T21:42:44.942Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/fbed29775b0612f4f5679d3226268f1a347161abc1727b4080fb41d9f46f/uv-0.11.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5985a15a92bd9a170fc1947abb1fbc3e9828c5a430ad85b5bed8356c20b67a71", size = 23609640, upload-time = "2026-04-15T21:42:22.57Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/de/989a69634a869a22322770120557c2d8cbba5b77ec7cfad326b4ec0f0547/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:fab0bb43fbbc0ee5b5fee212078d2300c371b725faff7cf72eeaafa0bff0606b", size = 23322484, upload-time = "2026-04-15T21:43:26.52Z" },
-    { url = "https://files.pythonhosted.org/packages/24/08/c1af05ea602eb4eb75d86badb6b0594cc104c3ca83ccf06d9ed4dd2186ad/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:23d457d6731ebdb83f1bffebe4894edab2ef43c1ec5488433c74300db4958924", size = 23326385, upload-time = "2026-04-15T21:42:41.32Z" },
-    { url = "https://files.pythonhosted.org/packages/68/99/e246962da06383e992ecab55000c62a50fb36efef855ea7264fad4816bf4/uv-0.11.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d6a17507b8139b8803f445a03fd097f732ce8356b1b7b13cdb4dd8ef7f4b2e0", size = 24985751, upload-time = "2026-04-15T21:42:37.777Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2d/b0b68083859579ce811996c1480765ec6a2442b44c451eaef53e6218fbae/uv-0.11.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd48823ca4b505124389f49ae50626ba9f57212b9047738efc95126ed5f3844d", size = 25724160, upload-time = "2026-04-15T21:43:18.762Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/19/5970e89d9e458fd3c4966bbc586a685a1c0ab0a8bf334503f63fa20b925b/uv-0.11.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb91f52ee67e10d5290f2c2897e2171357f1a10966de38d83eefa93d96843b0c", size = 25028512, upload-time = "2026-04-15T21:43:02.721Z" },
-    { url = "https://files.pythonhosted.org/packages/83/eb/4e1557daf6693cb446ed28185664ad6682fd98c6dbac9e433cbc35df450a/uv-0.11.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e4d5e31bea86e1b6e0f5a0f95e14e80018e6f6c0129256d2915a4b3d793644d", size = 24933975, upload-time = "2026-04-15T21:42:18.828Z" },
-    { url = "https://files.pythonhosted.org/packages/68/55/3b517ec8297f110d6981f525cccf26f86e30883fbb9c282769cffbcdcfca/uv-0.11.7-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:ceae53b202ea92bc954759bc7c7570cdcd5c3512fce15701198c19fd2dfb8605", size = 23706403, upload-time = "2026-04-15T21:43:10.664Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/30/7d93a0312d60e147722967036dc8ea37baab4802784bddc22464cb707deb/uv-0.11.7-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:f97e9f4e4d44fb5c4dfaa05e858ef3414a96416a2e4af270ecd88a3e5fb049a9", size = 24495797, upload-time = "2026-04-15T21:42:26.538Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/89/d49480bdab7725d36982793857e461d471bde8e1b7f438ffccee677a7bf8/uv-0.11.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:750ee5b96959b807cf442b73dd8b55111862d63f258f896787ea5f06b68aaca9", size = 24580471, upload-time = "2026-04-15T21:42:52.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/9f/c57dc03b48be17b564e304eb9ff982890c12dfb888b1ce370788733329ab/uv-0.11.7-py3-none-musllinux_1_1_i686.whl", hash = "sha256:f394331f0507e80ee732cb3df737589de53bed999dd02a6d24682f08c2f8ac4f", size = 24113637, upload-time = "2026-04-15T21:42:34.094Z" },
-    { url = "https://files.pythonhosted.org/packages/13/ba/b87e358b629a68258527e3490e73b7b148770f4d2257842dea3b7981d4e8/uv-0.11.7-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0df59ab0c6a4b14a763e8445e1c303af9abeb53cdfa4428daf9ff9642c0a3cce", size = 25119850, upload-time = "2026-04-15T21:43:22.529Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/74/16d229e1d8574bcbafa6dc643ac20b70c3e581f42ac31a6f4fd53035ffe3/uv-0.11.7-py3-none-win32.whl", hash = "sha256:553e67cc766d013ce24353fecd4ea5533d2aedcfd35f9fac430e07b1d1f23ed4", size = 22918454, upload-time = "2026-04-15T21:42:58.702Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/1d/b73e473da616ac758b8918fb218febcc46ddf64cba9e03894dfa226b28bd/uv-0.11.7-py3-none-win_amd64.whl", hash = "sha256:5674dfb5944513f4b3735b05c2deba6b1b01151f46729d533d413a9a905f8c5d", size = 25447744, upload-time = "2026-04-15T21:42:48.813Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/bb/e6bfdea92ed270f3445a5a3c17599d041b3f2dbc5026c09e02830a03bbaf/uv-0.11.7-py3-none-win_arm64.whl", hash = "sha256:6158b7e39464f1aa1e040daa0186cae4749a78b5cd80ac769f32ca711b8976b1", size = 23941816, upload-time = "2026-04-15T21:43:06.732Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/15/9b2138b16eb1fa8c2cd84b1037ad10c38b3acc36ce96c6d27000bfb7e716/uv-0.11.14-py3-none-linux_armv6l.whl", hash = "sha256:78411a883f230a710af19f2ac6e6f0ba8eae90f0e5af4605f923fd367539fff4", size = 23545199, upload-time = "2026-05-12T18:01:34.526Z" },
+    { url = "https://files.pythonhosted.org/packages/75/81/c678e8b9a8e624f9c338c66cd57dd9cfc6b5a0501ad3c87fd0cc0bf8850a/uv-0.11.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:078f2e63da89c8fcf6d578f02156045c5990c57d76464aab3f3f798d3fff95cd", size = 22957064, upload-time = "2026-05-12T18:00:54.225Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ad/95fbd15b23f26f36d0cfb0ddf159b9602a1b1c0feced60a7f98385e919f1/uv-0.11.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dcdad43d52c130e3159e84ab1844e04d819d2c4a2495a687d27f80d560a3650e", size = 21678307, upload-time = "2026-05-12T18:00:57.132Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cb/b3da1c4d95d6dd507896bca16dbd643118013b2b151f5f35a08d3391728c/uv-0.11.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:9923da7c63d70de9fe71829503d7e7ebfd6304e804d7232aad5f716e190db25b", size = 23353409, upload-time = "2026-05-12T18:01:27.512Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ad/78c6b8d6bcc04c5043b50631e9b413422a03a0bd7c4a997748f8e9cbac25/uv-0.11.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:3b0759ca504e48dcd4fafb1a61ef69aeb24c5a60fbf5f504a7873c8db1b24718", size = 23103964, upload-time = "2026-05-12T18:01:31.094Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7d/acb66e09bc54a74e4288e996d841af04d88588fd6bdbfbab2468ab7169a7/uv-0.11.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:78b51b117549ee4db7197ea5ece0848cecd443e464fb9dff9f254cdc1e4ed96f", size = 23104638, upload-time = "2026-05-12T18:01:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0a/8497be61accdb8e56d02e11edd3ac471466259420e0bd9c05c1966df134a/uv-0.11.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1ddbe8a2ab160affc179e9c3a40913b23a08cdf55254e1f3829cc22a51a0d8d", size = 24625888, upload-time = "2026-05-12T18:01:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/95/91/f730799fd20a45777b255e20cf9f648a4e4e0979bf65e87a8633197cf7d9/uv-0.11.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3005a2db1e8d72e125630d4f22ac4ceddb2c033e1f9b94b7f3ea38ebac46dd6", size = 25445231, upload-time = "2026-05-12T18:00:40.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/106463fc27e63e402aec2e791774dac2db5bd5e1c36cdcf38125aa97ab1c/uv-0.11.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5c8f9ea36274ef2f9d24f0522085e280844172e901d9213f66a21b212266706", size = 24571961, upload-time = "2026-05-12T18:00:43.713Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4d/163fe746b97bd1129627e8b1f943e17583ddc143eaab532d56a799a9ba5a/uv-0.11.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:379e64b236cf55f762a8308d7efe4365d5296ba29f3a4868761bc45b4e915a71", size = 24718523, upload-time = "2026-05-12T18:01:06.587Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fb/7a3673494a0cf70267559166398f9c50c4925ff20122f99a28d6c5a80d83/uv-0.11.14-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:29c12a562441fc2d604e6920c558cacce74a55f889468708683a79b35a6e18a1", size = 23454821, upload-time = "2026-05-12T18:00:51.166Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/43/6358394a567d865f3a5ce27b1e0d939549911e36d9b59f0c545a167f92f7/uv-0.11.14-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:e84069681c0334e07cbc7f114eb09d7fe1335e1db0297a66dbca80a1b393fe6d", size = 24087843, upload-time = "2026-05-12T18:00:47.272Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f6/7d0ae1e1f52b85057ca24d8876d6a4cc87b541ea6aca627fe36594c06099/uv-0.11.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b15bf7c146e38d7c938d3a207115d5fdd8ef764fe1f866c225b1bed27e88da1e", size = 24147611, upload-time = "2026-05-12T18:01:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a2/511ad0c5da5697fd990b99569425b62b81cbc3458c35acc845211b55d6b5/uv-0.11.14-py3-none-musllinux_1_1_i686.whl", hash = "sha256:ddda5c5e41097814adac535c74851bae55e8097b9afc79aeae7fcffd8d86c06d", size = 23920348, upload-time = "2026-05-12T18:01:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b6/7084e3401b1f1020f215a125136eec1ed2bd541e10a5fea1625515579599/uv-0.11.14-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:e54326703f1eca83a6fd73275e0f398b16b7d3f81531bf58899c2869bc403f6c", size = 24928981, upload-time = "2026-05-12T18:01:13.961Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6a/7e81729fe729889c8cc63bbf64291734359bd7f6ba84852dc0504453511d/uv-0.11.14-py3-none-win32.whl", hash = "sha256:b384d873d0d18552c7524226125efd3965d921b7134c2f476c333771beb733e1", size = 22573503, upload-time = "2026-05-12T18:00:34.36Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5d/f8905f9af5cd46af2a688b2246dbb5a4d95b8557eeffd7f241e037659d9e/uv-0.11.14-py3-none-win_amd64.whl", hash = "sha256:f0a8b58b38e984241bca5d7a5a47bf9ffe1ca2ab392a640887db8a04c4a9ec95", size = 25175590, upload-time = "2026-05-12T18:01:00.38Z" },
+    { url = "https://files.pythonhosted.org/packages/04/cb/7333d08d944f3018eb89242cd5e646e7b37faa1b567faeaf9254a8b59d53/uv-0.11.14-py3-none-win_arm64.whl", hash = "sha256:6a13e7e064563050c6606b3fd77091d427cdbdc5938b6f134baf8d8ec79bfdb7", size = 23594775, upload-time = "2026-05-12T18:01:03.55Z" },
 ]
 
 [[package]]
 name = "uvicorn"
-version = "0.45.0"
+version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/62b0d9a2cfc8b4de6771322dae30f2db76c66dae9ec32e94e176a44ad563/uvicorn-0.45.0.tar.gz", hash = "sha256:3fe650df136c5bd2b9b06efc5980636344a2fbb840e9ddd86437d53144fa335d", size = 87818, upload-time = "2026-04-21T10:43:46.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/88/d0f7512465b166a4e931ccf7e77792be60fb88466a43964c7566cbaff752/uvicorn-0.45.0-py3-none-any.whl", hash = "sha256:2db26f588131aeec7439de00f2dd52d5f210710c1f01e407a52c90b880d1fd4f", size = 69838, upload-time = "2026-04-21T10:43:45.029Z" },
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]
 
 [package.optional-dependencies]
@@ -2461,7 +2497,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.4"
+version = "21.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -2469,9 +2505,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
 ]
 
 [[package]]
@@ -2510,11 +2546,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add new migration commands. `sasquatch influxdb` is now split into `line-protocol` for the existing file-level commands, and `migrate` for a new database migration workflow.

Summary of migration phases:

- `discover`: validate inputs, locate shard data, and populate the manifest.
- `export`: export each TSM file to line protocol.
- `transform`: apply Sasquatch line protocol transformations in place.
- `import`: optionally import each transformed file individually into the target InfluxDB instance.

The migration manifest tracks per-file discovery, export, transform, and import progress, along with transform plan metadata, staged file paths, log paths, and any recorded errors.

- `status`: computes per-shard progress from the existing manifest and renders a plain-text report with a run summary.

Also add `influx_inspect` and `influx` to the main application image via a dedicated Docker build stage so the export and import commands can run in deployed environments.
